### PR TITLE
Optimize whiten ps

### DIFF
--- a/.vscode_shared/BenHimes/settings.json
+++ b/.vscode_shared/BenHimes/settings.json
@@ -105,7 +105,8 @@
         "__bit_reference": "cpp",
         "__functional_base": "cpp",
         "__node_handle": "cpp",
-        "__memory": "cpp"
+        "__memory": "cpp",
+        "locale": "cpp"
     },
     "C_Cpp.clang_format_path": "/usr/bin/clang-format-14",
     "editor.formatOnSave": true,

--- a/.vscode_shared/BenHimes/settings.json
+++ b/.vscode_shared/BenHimes/settings.json
@@ -101,7 +101,11 @@
         "compare": "cpp",
         "concepts": "cpp",
         "semaphore": "cpp",
-        "stop_token": "cpp"
+        "stop_token": "cpp",
+        "__bit_reference": "cpp",
+        "__functional_base": "cpp",
+        "__node_handle": "cpp",
+        "__memory": "cpp"
     },
     "C_Cpp.clang_format_path": "/usr/bin/clang-format-14",
     "editor.formatOnSave": true,

--- a/src/core/cistem_constants.h
+++ b/src/core/cistem_constants.h
@@ -8,6 +8,14 @@ namespace cistem {
 constexpr const int fraction_of_box_size_to_exclude_for_border = 4;
 constexpr const int maximum_number_of_detections               = 1000;
 
+namespace gpu {
+
+constexpr int warp_size             = 32;
+constexpr int min_threads_per_block = warp_size;
+constexpr int max_threads_per_block = 1024;
+
+} // namespace gpu
+
 /*
     SCOPED ENUMS:
         Rather than specifying a scoped enum as enum class, we use the following technique to define scoped enums while

--- a/src/core/conjugate_gradient.cpp
+++ b/src/core/conjugate_gradient.cpp
@@ -1,15 +1,16 @@
 #include "core_headers.h"
 
 ConjugateGradient::ConjugateGradient( ) {
-    is_in_memory       = false;
-    n                  = 0;
-    num_function_calls = 0;
-    best_values        = NULL;
-    e                  = NULL;
-    escale             = 0;
-    best_score         = std::numeric_limits<float>::max( );
-    target_function    = NULL;
-    parameters         = NULL;
+    is_in_memory           = false;
+    n                      = 0;
+    num_function_calls     = 0;
+    n_calls_made_by_va04a_ = 0;
+    best_values            = NULL;
+    e                      = NULL;
+    escale                 = 0;
+    best_score             = std::numeric_limits<float>::max( );
+    target_function        = NULL;
+    parameters             = NULL;
 }
 
 ConjugateGradient::~ConjugateGradient( ) {
@@ -41,8 +42,9 @@ float ConjugateGradient::Init(float (*function_to_minimize)(void* parameters, fl
     is_in_memory = true;
 
     // Initialise values
-    escale             = 100.0;
-    num_function_calls = 0;
+    escale                 = 100.0;
+    num_function_calls     = 0;
+    n_calls_made_by_va04a_ = 0;
 
     for ( int dim_counter = 0; dim_counter < n; dim_counter++ ) {
         best_values[dim_counter] = starting_value[dim_counter];
@@ -61,8 +63,10 @@ float ConjugateGradient::Run(int maxit) {
     int icon   = 1;
     //	int maxit = 50;
     int va04_success = 0;
+    // It seems the return value was not used anywhere, so I am having it instead return the number of function calls, which is
+    // useful to know when profiling changes to code that may change the number of function calls.
 
     va04_success = va04a_(&n, e, &escale, &num_function_calls, target_function, parameters, &best_score, &iprint, &icon, &maxit, best_values);
-
+    n_calls_made_by_va04a_ += long(num_function_calls);
     return best_score;
 }

--- a/src/core/conjugate_gradient.h
+++ b/src/core/conjugate_gradient.h
@@ -4,7 +4,8 @@ class ConjugateGradient {
   private:
     bool   is_in_memory;
     int    n; //	Number of parameters to refine
-    int    num_function_calls; //	Number of calls to the scoring function
+    int    num_function_calls; //	Number of calls to the scoring function this run
+    long   n_calls_made_by_va04a_; //	Number of calls to the scoring function cummulative
     float* best_values; //	Final best parameters determined by conjugate gradient minimization
     float* e; //	Recalculated accuracy for subroutine va04
     float  escale; //	Anticipated change in the parameters during conjugate gradient minimization
@@ -12,6 +13,7 @@ class ConjugateGradient {
     //
     float (*target_function)(void* parameters, float[]);
     void* parameters;
+
 
   public:
     // Constructors & destructors
@@ -21,6 +23,13 @@ class ConjugateGradient {
     // Methods
     float Init(float (*function_to_minimize)(void* parameters, float[]), void* parameters, int num_dim, float starting_value[], float accuracy[]);
     float Run(int maxit = 50);
+
+    inline long GetNumFunctionCalls( ) { 
+      long tmp = n_calls_made_by_va04a_;
+      n_calls_made_by_va04a_ = 0;
+      num_function_calls = 0;
+      return tmp; 
+    }
 
     inline float GetBestValue(int index) { return best_values[index]; };
 

--- a/src/core/va04.cpp
+++ b/src/core/va04.cpp
@@ -713,6 +713,7 @@ L106:
         goto L107;
     }
 L20:
+    *num_function_calls = iterc;
     return 0;
 L107:
     inn = 1;
@@ -724,6 +725,7 @@ L999:
     *f = target_function(parameters, x + 1);
     // Removed this statement since it does not seem to be very informative
     // wxPrintf("Warning(VA04): Endless loop safety catch, icnt = %i\n", icnt);
+    *num_function_calls = iterc;
     return 0;
 } /* va04a_ */
 

--- a/src/gpu/GpuImage.cu
+++ b/src/gpu/GpuImage.cu
@@ -1340,6 +1340,8 @@ __global__ void WhitenKernel(cufftComplex* input_values,
     for ( int iBlock = 0; iBlock < gridDim.x * gridDim.y; iBlock++ ) {
         offset = n_bins * iBlock;
         for ( int i = threadIdx.x + threadIdx.y * blockDim.x; i < n_bins; i += blockDim.x * blockDim.y ) {
+            // FIXME: Coalescing
+
             radial_average[i] += input_radial_average[i + offset];
             non_zero_count[i] += input_non_zero_count[i + offset];
         }
@@ -3103,7 +3105,7 @@ bool GpuImage::Allocate(int wanted_x_size, int wanted_y_size, int wanted_z_size,
             // everything is already done..
             is_in_real_space = should_be_in_real_space;
             //			wxPrintf("returning\n");
-            return;
+            return false;
         }
         else {
             Deallocate( );

--- a/src/gpu/GpuImage.cu
+++ b/src/gpu/GpuImage.cu
@@ -9,7 +9,7 @@
 
 #include "gpu_core_headers.h"
 #include "GpuImage.h"
-
+#include "gpu_indexing_functions.h"
 // #define USE_ASYNC_MALLOC_FREE
 // #define USE_BLOCK_REDUCE
 
@@ -1256,20 +1256,23 @@ __global__ void RotationalAveragePSKernel(const __restrict__ cufftComplex* input
                                           const int                        n_bins2,
                                           const float                      resolution_limit) {
 
-    int x = blockIdx.x * blockDim.x + threadIdx.x;
+    int x = physical_X( );
     if ( x >= NX ) {
         return;
     }
-    int y = blockIdx.y * blockDim.y + threadIdx.y;
+    int y = physical_Y( );
     if ( y >= NY ) {
         return;
     }
 
+    // Organize the shared memory as packed int for count, followed by packed float for rotational average
     extern __shared__ int non_zero_count[];
     float*                radial_average = (float*)&non_zero_count[n_bins];
 
     // initialize temporary accumulation array in shared memory
-    for ( int i = threadIdx.x + threadIdx.y * blockDim.x; i < n_bins; i += blockDim.x * blockDim.y ) {
+    // Every thread in the block writes in, and if the block is < n_bins, the slack will be picked up by the strided loop
+    // TODO: LaunchParameters that adjusts the size to reduce thread stalling by reducing the remainder of block size and n_bins
+    for ( int i = LinearThreadIdxInBlock_2dGrid( ); i < n_bins; i += BlockDimension( ) ) {
         radial_average[i] = 0.f;
         non_zero_count[i] = 0;
     }
@@ -1297,10 +1300,11 @@ __global__ void RotationalAveragePSKernel(const __restrict__ cufftComplex* input
     __syncthreads( );
 
     // Now write out the partial PS to global memory
-    int*   output_non_zero_count = &rotational_average_ps[n_bins * (blockIdx.x + blockIdx.y * gridDim.x)];
-    float* output_radial_average = (float*)&output_non_zero_count[n_bins * gridDim.x * gridDim.y];
+    // All the int values are packed for each block, followed by the float values
+    int*   output_non_zero_count = &rotational_average_ps[n_bins * LinearBlockIdx_2dGrid( )];
+    float* output_radial_average = (float*)&output_non_zero_count[n_bins * GridDimension_2d( )];
 
-    for ( int i = threadIdx.x + threadIdx.y * blockDim.x; i < n_bins; i += blockDim.x * blockDim.y ) {
+    for ( int i = LinearThreadIdxInBlock_2dGrid( ); i < n_bins; i += BlockDimension( ) ) {
         output_radial_average[i] = radial_average[i];
         output_non_zero_count[i] = non_zero_count[i];
     }
@@ -1312,22 +1316,25 @@ __global__ void WhitenKernel(cufftComplex* input_values,
                              const int     NY,
                              const int     n_bins,
                              const int     n_bins2,
+                             const int     n_blocks_previous_kernel,
                              const float   resolution_limit) {
 
-    int x = blockIdx.x * blockDim.x + threadIdx.x;
+    int x = physical_X_1d_grid( );
     if ( x >= NX ) {
         return;
     }
-    int y = blockIdx.y * blockDim.y + threadIdx.y;
-    if ( y >= NY ) {
+    if ( physical_Y_1d_grid( ) >= NY ) {
         return;
     }
+
+    int linear_idx = physical_Y_1d_grid( ) * NX + x;
 
     extern __shared__ int non_zero_count[];
     float*                radial_average = (float*)&non_zero_count[n_bins];
 
     // initialize temporary accumulation array in shared memory
-    for ( int i = threadIdx.x + threadIdx.y * blockDim.x; i < n_bins; i += blockDim.x * blockDim.y ) {
+    // Since this is a 1d block, we only care about the x position in that block
+    for ( int i = threadIdx.x; i < n_bins; i += blockDim.x ) {
         radial_average[i] = 0.f;
         non_zero_count[i] = 0;
     }
@@ -1335,27 +1342,23 @@ __global__ void WhitenKernel(cufftComplex* input_values,
 
     // Now aggregate out the partial PS to global memory
 
-    const float* input_radial_average = (float*)&input_non_zero_count[n_bins * gridDim.x * gridDim.y];
+    //
+    const float* input_radial_average = (float*)&input_non_zero_count[n_bins * n_blocks_previous_kernel];
     int          offset;
-    for ( int iBlock = 0; iBlock < gridDim.x * gridDim.y; iBlock++ ) {
+    for ( int iBlock = 0; iBlock < n_blocks_previous_kernel; iBlock++ ) {
         offset = n_bins * iBlock;
-        for ( int i = threadIdx.x + threadIdx.y * blockDim.x; i < n_bins; i += blockDim.x * blockDim.y ) {
-            // FIXME: Coalescing
-
+        for ( int i = threadIdx.x; i < n_bins; i += blockDim.x ) {
             radial_average[i] += input_radial_average[i + offset];
             non_zero_count[i] += input_non_zero_count[i + offset];
         }
     }
     __syncthreads( );
 
-    int v;
+    int v = physical_Y_1d_grid( );
 
     // First negative logical fourier component is at NY/2
-    if ( y >= NY / 2 ) {
-        v = y - NY;
-    }
-    else {
-        v = y;
+    if ( v >= NY / 2 ) {
+        v -= NY;
     }
 
     int bin = int(sqrtf(float(x * x + v * v) / float(NY) * n_bins2));
@@ -1363,17 +1366,17 @@ __global__ void WhitenKernel(cufftComplex* input_values,
     if ( bin <= resolution_limit && non_zero_count[bin] != 0 ) {
         float norm = sqrtf(non_zero_count[bin] / radial_average[bin]);
         if ( isfinite(norm) ) {
-            input_values[y * NX + x].x *= norm;
-            input_values[y * NX + x].y *= norm;
+            input_values[linear_idx].x *= norm;
+            input_values[linear_idx].y *= norm;
         }
         else {
-            input_values[y * NX + x].x = 0.f;
-            input_values[y * NX + x].y = 0.f;
+            input_values[linear_idx].x = 0.f;
+            input_values[linear_idx].y = 0.f;
         }
     }
     else {
-        input_values[y * NX + x].x = 0.f;
-        input_values[y * NX + x].y = 0.f;
+        input_values[linear_idx].x = 0.f;
+        input_values[linear_idx].y = 0.f;
     }
 }
 
@@ -1386,15 +1389,15 @@ void GpuImage::Whiten(float resolution_limit) {
     ReturnLaunchParamters(dims, false);
 
     // assuming square images, otherwise this would be largest dimension
-    int number_of_bins = dims.y / 2 + 1;
+    const int number_of_bins = dims.y / 2 + 1;
     // Extend table to include corners in 3D Fourier space
-    int n_bins  = int(number_of_bins * sqrtf(3.0)) + 1;
-    int n_bins2 = 2 * (number_of_bins - 1);
+    const int n_bins  = int(number_of_bins * sqrtf(3.0)) + 1;
+    const int n_bins2 = 2 * (number_of_bins - 1);
     // For bin resolution of one pixel, uint16 should be plenty
-    int shared_mem = n_bins * (sizeof(float) + sizeof(int));
+    const int shared_mem = n_bins * (sizeof(float) + sizeof(int));
     // For coalescing in global memory (2d grid)
-    int   n_blocks               = gridDims.x * gridDims.y;
-    float resolution_limit_pixel = resolution_limit * dims.x;
+    const int   n_blocks               = gridDims.x * gridDims.y;
+    const float resolution_limit_pixel = resolution_limit * dims.x;
 
     int* rotational_average_ps;
 
@@ -1414,6 +1417,13 @@ void GpuImage::Whiten(float resolution_limit) {
                                                                                               resolution_limit_pixel);
     postcheck;
 
+    // The first part of this kernel loops over all radial averages (nblocks timers / block) but it is only n_bins large
+    // so limit to a 1d grid which achieves lower occupancy / kernel, but higher useful occupancy when multiple streams are using the device
+    // (which is pretty much always.)
+    const int stride_y = 2;
+    // ReturnLaunchParamters1d_X_strided_Y(dims, false, stride_y);
+    ReturnLaunchParamters1d_X(dims, false);
+
     precheck;
     WhitenKernel<<<gridDims, threadsPerBlock, shared_mem, cudaStreamPerThread>>>(complex_values_gpu,
                                                                                  rotational_average_ps,
@@ -1421,6 +1431,7 @@ void GpuImage::Whiten(float resolution_limit) {
                                                                                  dims.y,
                                                                                  n_bins,
                                                                                  n_bins2,
+                                                                                 n_blocks,
                                                                                  resolution_limit_pixel);
     postcheck;
 

--- a/src/gpu/GpuImage.cu
+++ b/src/gpu/GpuImage.cu
@@ -1363,32 +1363,33 @@ __global__ void WhitenKernel(cufftComplex* input_values,
 
     extern __shared__ ValueAndWeight shared_rotational_average_ps[];
 
-    // initialize temporary accumulation array in shared memory
-    // Since this is a 1d block, we only care about the x position in that block
-    for ( int i = LinearThreadIdxInBlock_2dGrid( ); i < n_bins; i += BlockDimension_2d( ) ) {
-        shared_rotational_average_ps[i].value  = 0.f;
-        shared_rotational_average_ps[i].weight = 0;
-    }
-    __syncthreads( );
-
     int offset;
 #ifdef USE_FP16_FOR_WHITENPS
     ValueAndWeight_half tmp;
 #endif
 
-#pragma unroll 4
+    // Note this only works if n_threads_per_block > n_bins. Then every thread in the block only accesses one address in shared mem.
+    // This allows us to skip initializing the shared mem to zero, accumulate in thread registers (*skipping nBlocks writes to shared mem)
+    // and then only call one sync at the end.
+    float value  = 0.f;
+    int   weight = 0;
     for ( int iBlock = 0; iBlock < GridDimension_2d( ); iBlock++ ) {
         offset = n_bins * iBlock;
         for ( int i = LinearThreadIdxInBlock_2dGrid( ); i < n_bins; i += BlockDimension_2d( ) ) {
 #ifdef USE_FP16_FOR_WHITENPS
             tmp = rotational_average_ps[offset + i];
-            shared_rotational_average_ps[i].value += __bfloat162float(tmp.value);
-            shared_rotational_average_ps[i].weight += int(tmp.weight);
+            value += __bfloat162float(tmp.value);
+            weight += int(tmp.weight);
 #else
-            shared_rotational_average_ps[i].value += rotational_average_ps[i + offset].value;
-            shared_rotational_average_ps[i].weight += rotational_average_ps[i + offset].weight;
+            value += rotational_average_ps[i + offset].value;
+            weight += rotational_average_ps[i + offset].weight;
 #endif
         }
+    }
+
+    for ( int i = LinearThreadIdxInBlock_2dGrid( ); i < n_bins; i += BlockDimension_2d( ) ) {
+        shared_rotational_average_ps[i].value  = value;
+        shared_rotational_average_ps[i].weight = weight;
     }
     __syncthreads( );
 
@@ -1424,13 +1425,15 @@ void GpuImage::Whiten(float resolution_limit) {
     MyDebugAssertTrue(dims.z == 1, "Whitening is only setup to work in 2D");
 
     // First we need to get the rotationally averaged PS, which we'll store in global memory
-    ReturnLaunchParamters(dims, false);
+    ReturnLaunchParamters<ntds_x_WhitenPS, ntds_y_WhitenPS>(dims, false);
 
     // assuming square images, otherwise this would be largest dimension
     const int number_of_bins = dims.y / 2 + 1;
     // Extend table to include corners in 3D Fourier space
     const int n_bins  = int(number_of_bins * sqrtf(3.0)) + 1;
     const int n_bins2 = 2 * (number_of_bins - 1);
+
+    MyAssertFalse(n_bins > ntds_x_WhitenPS * ntds_y_WhitenPS, "n_bins is too large and would require an array for local variable storage. The size must be  known at compile time so make a template specialization  of the kernel.");
 // For bin resolution of one pixel, uint16 should be plenty
 #ifdef USE_FP16_FOR_WHITENPS
     ValueAndWeight_half* rotational_average_ps;

--- a/src/gpu/GpuImage.cu
+++ b/src/gpu/GpuImage.cu
@@ -201,6 +201,12 @@ typedef struct
     }
 } square;
 
+typedef __align__(8) struct _ValueAndWeight {
+    static_assert(sizeof(float) == sizeof(int), "sizeof(float) != sizeof(int)");
+    float value;
+    int   weight;
+} _ValueAndWeight;
+
 // #define FULL_MASK 0xffffffff
 
 ////////////////////////
@@ -1316,45 +1322,42 @@ __global__ void WhitenKernel(cufftComplex* input_values,
                              const int     NY,
                              const int     n_bins,
                              const int     n_bins2,
-                             const int     n_blocks_previous_kernel,
                              const float   resolution_limit) {
 
-    int x = physical_X_1d_grid( );
+    int x = physical_X( );
     if ( x >= NX ) {
         return;
     }
-    if ( physical_Y_1d_grid( ) >= NY ) {
+    if ( physical_Y( ) >= NY ) {
         return;
     }
 
-    int linear_idx = physical_Y_1d_grid( ) * NX + x;
+    int linear_idx = physical_Y( ) * NX + x;
 
     extern __shared__ int non_zero_count[];
     float*                radial_average = (float*)&non_zero_count[n_bins];
 
     // initialize temporary accumulation array in shared memory
     // Since this is a 1d block, we only care about the x position in that block
-    for ( int i = threadIdx.x; i < n_bins; i += blockDim.x ) {
+    for ( int i = LinearThreadIdxInBlock_2dGrid( ); i < n_bins; i += BlockDimension( ) ) {
         radial_average[i] = 0.f;
         non_zero_count[i] = 0;
     }
     __syncthreads( );
 
-    // Now aggregate out the partial PS to global memory
-
-    //
-    const float* input_radial_average = (float*)&input_non_zero_count[n_bins * n_blocks_previous_kernel];
+    const float* input_radial_average = (float*)&input_non_zero_count[n_bins * LinearBlockIdx_2dGrid( )];
     int          offset;
-    for ( int iBlock = 0; iBlock < n_blocks_previous_kernel; iBlock++ ) {
+#pragma unroll 4
+    for ( int iBlock = 0; iBlock < GridDimension_2d( ); iBlock++ ) {
         offset = n_bins * iBlock;
-        for ( int i = threadIdx.x; i < n_bins; i += blockDim.x ) {
+        for ( int i = LinearThreadIdxInBlock_2dGrid( ); i < n_bins; i += BlockDimension( ) ) {
             radial_average[i] += input_radial_average[i + offset];
             non_zero_count[i] += input_non_zero_count[i + offset];
         }
     }
     __syncthreads( );
 
-    int v = physical_Y_1d_grid( );
+    int v = physical_Y( );
 
     // First negative logical fourier component is at NY/2
     if ( v >= NY / 2 ) {
@@ -1417,13 +1420,6 @@ void GpuImage::Whiten(float resolution_limit) {
                                                                                               resolution_limit_pixel);
     postcheck;
 
-    // The first part of this kernel loops over all radial averages (nblocks timers / block) but it is only n_bins large
-    // so limit to a 1d grid which achieves lower occupancy / kernel, but higher useful occupancy when multiple streams are using the device
-    // (which is pretty much always.)
-    const int stride_y = 2;
-    // ReturnLaunchParamters1d_X_strided_Y(dims, false, stride_y);
-    ReturnLaunchParamters1d_X(dims, false);
-
     precheck;
     WhitenKernel<<<gridDims, threadsPerBlock, shared_mem, cudaStreamPerThread>>>(complex_values_gpu,
                                                                                  rotational_average_ps,
@@ -1431,7 +1427,6 @@ void GpuImage::Whiten(float resolution_limit) {
                                                                                  dims.y,
                                                                                  n_bins,
                                                                                  n_bins2,
-                                                                                 n_blocks,
                                                                                  resolution_limit_pixel);
     postcheck;
 

--- a/src/gpu/GpuImage.cu
+++ b/src/gpu/GpuImage.cu
@@ -12,6 +12,11 @@
 #include "gpu_indexing_functions.h"
 // #define USE_ASYNC_MALLOC_FREE
 // #define USE_BLOCK_REDUCE
+#define USE_FP16_FOR_WHITENPS
+
+#ifdef USE_FP16_FOR_WHITENPS
+#include <cuda_bf16.h>
+#endif
 
 __global__ void ConvertToHalfPrecisionKernelComplex(cufftComplex* complex_32f_values, __half2* complex_16f_values, int4 dims, int3 physical_upper_bound_complex);
 __global__ void ConvertToHalfPrecisionKernelReal(cufftReal* real_32f_values, __half* real_16f_values, int4 dims);
@@ -201,11 +206,18 @@ typedef struct
     }
 } square;
 
+typedef __align__(4) struct _ValueAndWeight_half {
+
+    static_assert(sizeof(nv_bfloat16) == sizeof(short), "sizeof(__half) != sizeof(short)");
+    nv_bfloat16 value;
+    short       weight;
+} ValueAndWeight_half;
+
 typedef __align__(8) struct _ValueAndWeight {
     static_assert(sizeof(float) == sizeof(int), "sizeof(float) != sizeof(int)");
     float value;
     int   weight;
-} _ValueAndWeight;
+} ValueAndWeight;
 
 // #define FULL_MASK 0xffffffff
 
@@ -1255,32 +1267,35 @@ __global__ void ApplyBFactorKernel(cufftComplex* d_input,
 }
 
 __global__ void RotationalAveragePSKernel(const __restrict__ cufftComplex* input_values,
-                                          int*                             rotational_average_ps,
-                                          const int                        NX,
-                                          const int                        NY,
-                                          const int                        n_bins,
-                                          const int                        n_bins2,
-                                          const float                      resolution_limit) {
+#ifdef USE_FP16_FOR_WHITENPS
+                                          ValueAndWeight_half* rotational_average_ps,
+#else
+                                          ValueAndWeight* rotational_average_ps,
+#endif
+                                          const int   NX,
+                                          const int   NY,
+                                          const int   n_bins,
+                                          const int   n_bins2,
+                                          const float resolution_limit) {
 
-    int x = physical_X( );
+    int x = physical_X_2d_grid( );
     if ( x >= NX ) {
         return;
     }
-    int y = physical_Y( );
+    int y = physical_Y_2d_grid( );
     if ( y >= NY ) {
         return;
     }
 
     // Organize the shared memory as packed int for count, followed by packed float for rotational average
-    extern __shared__ int non_zero_count[];
-    float*                radial_average = (float*)&non_zero_count[n_bins];
+    extern __shared__ ValueAndWeight shared_rotational_average_ps[];
 
     // initialize temporary accumulation array in shared memory
     // Every thread in the block writes in, and if the block is < n_bins, the slack will be picked up by the strided loop
     // TODO: LaunchParameters that adjusts the size to reduce thread stalling by reducing the remainder of block size and n_bins
-    for ( int i = LinearThreadIdxInBlock_2dGrid( ); i < n_bins; i += BlockDimension( ) ) {
-        radial_average[i] = 0.f;
-        non_zero_count[i] = 0;
+    for ( int i = LinearThreadIdxInBlock_2dGrid( ); i < n_bins; i += BlockDimension_2d( ) ) {
+        shared_rotational_average_ps[i].value  = 0.f;
+        shared_rotational_average_ps[i].weight = 0;
     }
     __syncthreads( );
 
@@ -1300,64 +1315,84 @@ __global__ void RotationalAveragePSKernel(const __restrict__ cufftComplex* input
     int   bin       = int(sqrtf(u * u + v * v) / float(NY) * n_bins2);
     // This check is from Image::Whiten, but should it really be checking a float like this?
     if ( abs_value != 0.0 && bin <= resolution_limit ) {
-        atomicAdd(&non_zero_count[bin], 1);
-        atomicAdd(&radial_average[bin], abs_value);
+        atomicAdd(&shared_rotational_average_ps[bin].value, abs_value);
+        atomicAdd(&shared_rotational_average_ps[bin].weight, 1);
     }
     __syncthreads( );
 
-    // Now write out the partial PS to global memory
-    // All the int values are packed for each block, followed by the float values
-    int*   output_non_zero_count = &rotational_average_ps[n_bins * LinearBlockIdx_2dGrid( )];
-    float* output_radial_average = (float*)&output_non_zero_count[n_bins * GridDimension_2d( )];
-
-    for ( int i = LinearThreadIdxInBlock_2dGrid( ); i < n_bins; i += BlockDimension( ) ) {
-        output_radial_average[i] = radial_average[i];
-        output_non_zero_count[i] = non_zero_count[i];
+// Now write out the partial PS to global memory
+// All the int values are packed for each block, followed by the float values
+#ifdef USE_FP16_FOR_WHITENPS
+    ValueAndWeight_half* output_rotational_average_ps = &rotational_average_ps[n_bins * LinearBlockIdx_2dGrid( )];
+    ValueAndWeight_half  tmp;
+    for ( int i = LinearThreadIdxInBlock_2dGrid( ); i < n_bins; i += BlockDimension_2d( ) ) {
+        tmp.value                       = __float2bfloat16(shared_rotational_average_ps[i].value);
+        tmp.weight                      = short(shared_rotational_average_ps[i].weight);
+        output_rotational_average_ps[i] = tmp;
     }
+#else
+    ValueAndWeight* output_rotational_average_ps = &rotational_average_ps[n_bins * LinearBlockIdx_2dGrid( )];
+    for ( int i = LinearThreadIdxInBlock_2dGrid( ); i < n_bins; i += BlockDimension_2d( ) ) {
+        output_rotational_average_ps[i] = shared_rotational_average_ps[i];
+    }
+#endif
 };
 
 __global__ void WhitenKernel(cufftComplex* input_values,
-                             int*          input_non_zero_count,
-                             const int     NX,
-                             const int     NY,
-                             const int     n_bins,
-                             const int     n_bins2,
-                             const float   resolution_limit) {
+#ifdef USE_FP16_FOR_WHITENPS
+                             ValueAndWeight_half* rotational_average_ps,
+#else
+                             ValueAndWeight* rotational_average_ps,
+#endif
+                             const int   NX,
+                             const int   NY,
+                             const int   n_bins,
+                             const int   n_bins2,
+                             const float resolution_limit) {
 
-    int x = physical_X( );
+    int x = physical_X_2d_grid( );
     if ( x >= NX ) {
         return;
     }
-    if ( physical_Y( ) >= NY ) {
+    int y = physical_Y_2d_grid( );
+    if ( y >= NY ) {
         return;
     }
 
-    int linear_idx = physical_Y( ) * NX + x;
+    int linear_idx = y * NX + x;
 
-    extern __shared__ int non_zero_count[];
-    float*                radial_average = (float*)&non_zero_count[n_bins];
+    extern __shared__ ValueAndWeight shared_rotational_average_ps[];
 
     // initialize temporary accumulation array in shared memory
     // Since this is a 1d block, we only care about the x position in that block
-    for ( int i = LinearThreadIdxInBlock_2dGrid( ); i < n_bins; i += BlockDimension( ) ) {
-        radial_average[i] = 0.f;
-        non_zero_count[i] = 0;
+    for ( int i = LinearThreadIdxInBlock_2dGrid( ); i < n_bins; i += BlockDimension_2d( ) ) {
+        shared_rotational_average_ps[i].value  = 0.f;
+        shared_rotational_average_ps[i].weight = 0;
     }
     __syncthreads( );
 
-    const float* input_radial_average = (float*)&input_non_zero_count[n_bins * LinearBlockIdx_2dGrid( )];
-    int          offset;
+    int offset;
+#ifdef USE_FP16_FOR_WHITENPS
+    ValueAndWeight_half tmp;
+#endif
+
 #pragma unroll 4
     for ( int iBlock = 0; iBlock < GridDimension_2d( ); iBlock++ ) {
         offset = n_bins * iBlock;
-        for ( int i = LinearThreadIdxInBlock_2dGrid( ); i < n_bins; i += BlockDimension( ) ) {
-            radial_average[i] += input_radial_average[i + offset];
-            non_zero_count[i] += input_non_zero_count[i + offset];
+        for ( int i = LinearThreadIdxInBlock_2dGrid( ); i < n_bins; i += BlockDimension_2d( ) ) {
+#ifdef USE_FP16_FOR_WHITENPS
+            tmp = rotational_average_ps[offset + i];
+            shared_rotational_average_ps[i].value += __bfloat162float(tmp.value);
+            shared_rotational_average_ps[i].weight += int(tmp.weight);
+#else
+            shared_rotational_average_ps[i].value += rotational_average_ps[i + offset].value;
+            shared_rotational_average_ps[i].weight += rotational_average_ps[i + offset].weight;
+#endif
         }
     }
     __syncthreads( );
 
-    int v = physical_Y( );
+    int v = y;
 
     // First negative logical fourier component is at NY/2
     if ( v >= NY / 2 ) {
@@ -1366,8 +1401,8 @@ __global__ void WhitenKernel(cufftComplex* input_values,
 
     int bin = int(sqrtf(float(x * x + v * v) / float(NY) * n_bins2));
     // float min_value = sqrtf(radial_average[1] / float(non_zero_count[1]) * 10e-2f);
-    if ( bin <= resolution_limit && non_zero_count[bin] != 0 ) {
-        float norm = sqrtf(non_zero_count[bin] / radial_average[bin]);
+    if ( bin <= resolution_limit && shared_rotational_average_ps[bin].weight != 0 ) {
+        float norm = sqrtf((shared_rotational_average_ps[bin].weight) / (shared_rotational_average_ps[bin].value));
         if ( isfinite(norm) ) {
             input_values[linear_idx].x *= norm;
             input_values[linear_idx].y *= norm;
@@ -1396,13 +1431,18 @@ void GpuImage::Whiten(float resolution_limit) {
     // Extend table to include corners in 3D Fourier space
     const int n_bins  = int(number_of_bins * sqrtf(3.0)) + 1;
     const int n_bins2 = 2 * (number_of_bins - 1);
-    // For bin resolution of one pixel, uint16 should be plenty
-    const int shared_mem = n_bins * (sizeof(float) + sizeof(int));
+// For bin resolution of one pixel, uint16 should be plenty
+#ifdef USE_FP16_FOR_WHITENPS
+    ValueAndWeight_half* rotational_average_ps;
+#else
+    ValueAndWeight* rotational_average_ps;
+#endif
+
+    const int shared_mem = n_bins * sizeof(ValueAndWeight);
+
     // For coalescing in global memory (2d grid)
     const int   n_blocks               = gridDims.x * gridDims.y;
     const float resolution_limit_pixel = resolution_limit * dims.x;
-
-    int* rotational_average_ps;
 
 #ifdef USE_ASYNC_MALLOC_FREE
     cudaErr(cudaMallocAsync(&rotational_average_ps, shared_mem * n_blocks, cudaStreamPerThread));
@@ -1492,7 +1532,7 @@ __global__ void _pre_GetWeightedCorrelationWithImageKernel(const __restrict__ cu
                 sum3 = v;
             }
 #else
-            image_PS[real_idx]      = ComplexModulusSquared(image_values[complex_idx]);
+            image_PS[real_idx] = ComplexModulusSquared(image_values[complex_idx]);
             projection_PS[real_idx] = ComplexModulusSquared(projection_values[complex_idx]);
             if ( u > signed_CC_limit_sq ) {
                 cross_terms[real_idx] = fabsf(v);
@@ -1514,8 +1554,8 @@ __global__ void _pre_GetWeightedCorrelationWithImageKernel(const __restrict__ cu
         sum2 = 0.f;
         sum3 = 0.f;
 #else
-        cross_terms[real_idx]   = 0.f;
-        image_PS[real_idx]      = 0.f;
+        cross_terms[real_idx] = 0.f;
+        image_PS[real_idx] = 0.f;
         projection_PS[real_idx] = 0.f;
 #endif
     }

--- a/src/gpu/GpuImage.h
+++ b/src/gpu/GpuImage.h
@@ -8,6 +8,8 @@
 #ifndef GPUIMAGE_H_
 #define GPUIMAGE_H_
 
+#include "../core/cistem_constants.h"
+
 class GpuImage {
 
   public:
@@ -237,14 +239,37 @@ class GpuImage {
     void UpdateBoolsToDefault( );
 
     __inline__ void ReturnLaunchParamters(int4 input_dims, bool real_space) {
-        int div;
-        if ( real_space ) {
-            div = 1;
-        }
-        else {
-            div = 2;
-        }
+        int div = 1;
+        if ( ! real_space )
+            div++;
+
         threadsPerBlock = dim3(32, 32, 1);
+        gridDims        = dim3((input_dims.w / div + threadsPerBlock.x - 1) / threadsPerBlock.x,
+                               (input_dims.y + threadsPerBlock.y - 1) / threadsPerBlock.y,
+                               input_dims.z);
+    };
+
+    __inline__ void ReturnLaunchParamters1d_X(const int4 input_dims, const bool real_space) {
+        int div = 1;
+        if ( ! real_space )
+            div++;
+
+        using namespace cistem::gpu;
+        // Note: that second set of parens changes the division!
+        threadsPerBlock = dim3(std::max(min_threads_per_block, std::min(max_threads_per_block, warp_size * ((input_dims.w / div + warp_size - 1) / warp_size))), 1, 1);
+        gridDims        = dim3((input_dims.w / div + threadsPerBlock.x - 1) / threadsPerBlock.x,
+                               (input_dims.y + threadsPerBlock.y - 1) / threadsPerBlock.y,
+                               input_dims.z);
+    };
+
+    __inline__ void ReturnLaunchParamters1d_X_strided_Y(const int4 input_dims, const bool real_space, const int stride_y) {
+        int div = 1;
+        if ( ! real_space )
+            div++;
+
+        using namespace cistem::gpu;
+        // Note: that second set of parens changes the division!
+        threadsPerBlock = dim3(std::max(min_threads_per_block, std::min(max_threads_per_block / stride_y, warp_size * ((input_dims.w / div + warp_size - 1) / warp_size))), stride_y, 1);
         gridDims        = dim3((input_dims.w / div + threadsPerBlock.x - 1) / threadsPerBlock.x,
                                (input_dims.y + threadsPerBlock.y - 1) / threadsPerBlock.y,
                                input_dims.z);

--- a/src/gpu/GpuImage.h
+++ b/src/gpu/GpuImage.h
@@ -238,12 +238,15 @@ class GpuImage {
     void SetupInitialValues( );
     void UpdateBoolsToDefault( );
 
+    template <int ntds_x = 32, int ntds_y = 32>
     __inline__ void ReturnLaunchParamters(int4 input_dims, bool real_space) {
+        static_assert(ntds_x % cistem::gpu::warp_size == 0);
+        static_assert(ntds_x * ntds_y <= cistem::gpu::max_threads_per_block);
         int div = 1;
         if ( ! real_space )
             div++;
 
-        threadsPerBlock = dim3(32, 32, 1);
+        threadsPerBlock = dim3(ntds_x, ntds_y, 1);
         gridDims        = dim3((input_dims.w / div + threadsPerBlock.x - 1) / threadsPerBlock.x,
                                (input_dims.y + threadsPerBlock.y - 1) / threadsPerBlock.y,
                                input_dims.z);

--- a/src/gpu/gpu_core_headers.h
+++ b/src/gpu/gpu_core_headers.h
@@ -33,6 +33,9 @@ const int MAX_GPU_COUNT = 32;
 
 // clang-format on
 
+// Limits for specific kernels
+constexpr int ntds_x_WhitenPS = 32;
+constexpr int ntds_y_WhitenPS = 32;
 // Complex data type
 typedef float2                            Complex;
 static __device__ __host__ inline Complex ComplexAdd(Complex, Complex);
@@ -114,7 +117,6 @@ static __device__ __host__ inline Complex ComplexConjMulAndScale(Complex a, Comp
     c.y = s * (a.y * b.x - a.x * b.y);
     return c;
 }
-
 
 // static constexpr int warpSize = 32;
 

--- a/src/gpu/gpu_core_headers.h
+++ b/src/gpu/gpu_core_headers.h
@@ -115,6 +115,7 @@ static __device__ __host__ inline Complex ComplexConjMulAndScale(Complex a, Comp
     return c;
 }
 
+
 // static constexpr int warpSize = 32;
 
 #endif /* GPU_CORE_HEADERS_H_ */

--- a/src/gpu/gpu_indexing_functions.h
+++ b/src/gpu/gpu_indexing_functions.h
@@ -1,0 +1,99 @@
+#ifndef _SRC_GPU_GPU_INDEXING_FUNCTIONS_H_
+#define _SRC_GPU_GPU_INDEXING_FUNCTIONS_H_
+
+__device__ __forceinline__ int LinearBlockIdx_2dGrid( ) {
+    return blockIdx.x + gridDim.x * blockIdx.y;
+}
+
+__device__ __forceinline__ int LinearBlockIdx_3dGrid( ) {
+    return blockIdx.x + gridDim.x * (blockIdx.y + blockIdx.z * gridDim.y);
+}
+
+__device__ __forceinline__ int LinearThreadIdxInBlock_2dGrid( ) {
+    return threadIdx.x + threadIdx.y * blockDim.x;
+}
+
+__device__ __forceinline__ int LinearThreadIdxInBlock_3dGrid( ) {
+    return threadIdx.x + blockDim.x * (threadIdx.y + threadIdx.z * blockDim.y);
+}
+
+__device__ __forceinline__ int GridDimension_2d( ) {
+    return gridDim.x * gridDim.y;
+}
+
+__device__ __forceinline__ int GridDimension_3d( ) {
+    return gridDim.x * gridDim.y * gridDim.z;
+}
+
+__device__ __forceinline__ int BlockDimension_2d( ) {
+    return blockDim.x * blockDim.y;
+}
+
+__device__ __forceinline__ int BlockDimension_3d( ) {
+    return blockDim.x * blockDim.y * blockDim.z;
+}
+
+__device__ __forceinline__ int physical_X_3d_grid( ) {
+    return blockIdx.x * blockDim.x + threadIdx.x;
+}
+
+__device__ __forceinline__ int physical_Y_3d_grid( ) {
+    return blockIdx.y * blockDim.y + threadIdx.y;
+}
+
+__device__ __forceinline__ int physical_Z_3d_grid( ) {
+    return blockIdx.z * blockDim.z + threadIdx.z;
+}
+
+__device__ __forceinline__ int physical_X_2d_grid( ) {
+    return physical_X_3d_grid( );
+}
+
+__device__ __forceinline__ int physical_Y_2d_grid( ) {
+    return physical_Y_3d_grid( );
+}
+
+__device__ __forceinline__ int physical_Z_2d_grid( ) {
+    return blockIdx.z;
+}
+
+__device__ __forceinline__ int physical_X_1d_grid( ) {
+    return physical_X_3d_grid( );
+}
+
+__device__ __forceinline__ int physical_Y_1d_grid( ) {
+    return blockIdx.y;
+}
+
+__device__ __forceinline__ int physical_Z_1d_grid( ) {
+    return blockIdx.z;
+}
+
+// In some cases, having the explicit name can clarify the code.
+// If not, alias the most generic method.
+
+__device__ __forceinline__ int LinearBlockIdx( ) {
+    return LinearBlockIdx_3dGrid( );
+}
+
+__device__ __forceinline__ int BlockDimension( ) {
+    return BlockDimension_3d( );
+}
+
+__device__ __forceinline__ int GridDimension( ) {
+    return GridDimension_3d( );
+}
+
+__device__ __forceinline__ int physical_X( ) {
+    return physical_X_3d_grid( );
+}
+
+__device__ __forceinline__ int physical_Y( ) {
+    return physical_Y_3d_grid( );
+}
+
+__device__ __forceinline__ int physical_Z( ) {
+    return physical_Z_3d_grid( );
+}
+
+#endif

--- a/src/programs/refine3d/refine3d.cpp
+++ b/src/programs/refine3d/refine3d.cpp
@@ -542,6 +542,7 @@ bool Refine3DApp::DoCalculation( ) {
 
     ZeroFloatArray(cg_starting_point, 17);
     ZeroFloatArray(cg_accuracy, 17);
+    long number_of_calls_to_score_function = 0;
 
     if ( (is_running_locally && ! DoesFileExist(input_star_filename)) || (! is_running_locally && ! DoesFileExistWithWait(input_star_filename, 90)) ) {
         SendErrorAndCrash(wxString::Format("Error: Input star file %s not found\n", input_star_filename));
@@ -999,24 +1000,25 @@ bool Refine3DApp::DoCalculation( ) {
 
     current_projection = 0;
 
-#pragma omp parallel num_threads(max_threads) default(none) shared(timer, parameter_average, input_3d, input_star_file, input_stack, max_threads, search_particle,                                                                                                                                                                       \
-                                                                   first_particle, last_particle, invert_contrast, normalize_particles, noise_power_spectrum, padding, ctf_refinement, defocus_search_range, defocus_step, normalize_input_3d,                                                                                           \
-                                                                   refine_statistics, pixel_size, my_progress, outer_mask_radius, mask_falloff, high_resolution_limit, molecular_mass_kDa, percent_used, output_shifts_file, local_refinement,                                                                                           \
-                                                                   binning_factor_refine, low_resolution_limit, input_statistics, output_star_file, current_projection, local_global_refine, signed_CC_limit, defocus_bias,                                                                                                              \
-                                                                   random_particle, defocus_range_mean2, defocus_range_std, defocus_mean_score, current_class, mask_radius_search, search_reference_3d, high_resolution_limit_search,                                                                                                    \
-                                                                   binning_factor_search, search_statistics, search_box_size, projection_cache, my_symmetry, angular_step, psi_max, psi_step, psi_start, take_random_best_parameter, refine_particle,                                                                                    \
-                                                                   skip_local_refinement, calculate_matching_projections, classification_resolution_limit, output_file, best_parameters_to_keep, ignore_input_angles, global_random_number_generator,                                                                                    \
-                                                                   global_euler_search, binned_image_box_size, binned_search_image_box_size, global_search) private(image_counter, refine_particle_local, current_line_local, input_parameters, temp_float, output_parameters, input_ctf, variance, average,                             \
-                                                                                                                                                                    best_score, defocus_i, score, cg_starting_point, input_image_local, search_particle_local, intermediate_result, gui_result_parameters, image_shift_x, image_shift_y, \
-                                                                                                                                                                    binned_image, projection_image_local, best_defocus_i, defocus_score, temp_image2_local, search_projection_image, cg_accuracy, search_reference_3d_local,             \
-                                                                                                                                                                    temp_image_local, search_parameters, istart, parameter_to_keep, conjugate_gradient_minimizer, i, final_image, input_3d_local, euler_search_local, frealign_score_local)
+#pragma omp parallel num_threads(max_threads) default(none) shared(timer, parameter_average, input_3d, input_star_file, input_stack, max_threads, search_particle,                                                                                                                                                                                                          \
+                                                                   first_particle, last_particle, invert_contrast, normalize_particles, noise_power_spectrum, padding, ctf_refinement, defocus_search_range, defocus_step, normalize_input_3d,                                                                                                                              \
+                                                                   refine_statistics, pixel_size, my_progress, outer_mask_radius, mask_falloff, high_resolution_limit, molecular_mass_kDa, percent_used, output_shifts_file, local_refinement,                                                                                                                              \
+                                                                   binning_factor_refine, low_resolution_limit, input_statistics, output_star_file, current_projection, local_global_refine, signed_CC_limit, defocus_bias,                                                                                                                                                 \
+                                                                   random_particle, defocus_range_mean2, defocus_range_std, defocus_mean_score, current_class, mask_radius_search, search_reference_3d, high_resolution_limit_search,                                                                                                                                       \
+                                                                   binning_factor_search, search_statistics, search_box_size, projection_cache, my_symmetry, angular_step, psi_max, psi_step, psi_start, take_random_best_parameter, refine_particle,                                                                                                                       \
+                                                                   skip_local_refinement, calculate_matching_projections, classification_resolution_limit, output_file, best_parameters_to_keep, ignore_input_angles, global_random_number_generator,                                                                                                                       \
+                                                                   global_euler_search, binned_image_box_size, binned_search_image_box_size, global_search, number_of_calls_to_score_function) private(image_counter, refine_particle_local, current_line_local, input_parameters, temp_float, output_parameters, input_ctf, variance, average,                             \
+                                                                                                                                                                                                       best_score, defocus_i, score, cg_starting_point, input_image_local, search_particle_local, intermediate_result, gui_result_parameters, image_shift_x, image_shift_y, \
+                                                                                                                                                                                                       binned_image, projection_image_local, best_defocus_i, defocus_score, temp_image2_local, search_projection_image, cg_accuracy, search_reference_3d_local,             \
+                                                                                                                                                                                                       temp_image_local, search_parameters, istart, parameter_to_keep, conjugate_gradient_minimizer, i, final_image, input_3d_local, euler_search_local, frealign_score_local)
     { // for omp
 
         timer.start("omp copy to local variables");
 
         ProjectionComparisonObjects comparison_object;
 
-        int new_buffer_size = 0;
+        int  new_buffer_size                         = 0;
+        long number_of_calls_to_score_function_local = 0;
 
         //	input_3d_local = input_3d;
         input_3d_local.CopyAllButVolume(&input_3d);
@@ -1493,6 +1495,7 @@ bool Refine3DApp::DoCalculation( ) {
                             input_parameters.score = output_parameters.score;
 
                         temp_float = -100.0 * conjugate_gradient_minimizer.Run(50);
+                        number_of_calls_to_score_function_local += conjugate_gradient_minimizer.GetNumFunctionCalls( );
 #ifdef PRINT_SCORES
                         wxPrintf("Current score is %g, from line %i\n", temp_float, __LINE__);
 #endif
@@ -1526,8 +1529,11 @@ bool Refine3DApp::DoCalculation( ) {
                             }
                             if ( skip_local_refinement )
                                 temp_float = search_parameters.score;
-                            else
+                            else {
                                 temp_float = -100.0 * conjugate_gradient_minimizer.Run(50);
+                                number_of_calls_to_score_function_local += conjugate_gradient_minimizer.GetNumFunctionCalls( );
+                            }
+
 #ifdef PRINT_SCORES
                             wxPrintf("Current score is %g, from line %i\n", temp_float, __LINE__);
 #endif
@@ -1576,6 +1582,8 @@ bool Refine3DApp::DoCalculation( ) {
                     temp_float = -100.0 * conjugate_gradient_minimizer.Init(&FrealignObjectiveFunction, &comparison_object, refine_particle_local.number_of_search_dimensions, cg_starting_point, cg_accuracy);
                     //???				if (! global_search) input_parameters[15] = temp_float;
                     output_parameters.score = -100.0 * conjugate_gradient_minimizer.Run(50);
+                    number_of_calls_to_score_function_local += conjugate_gradient_minimizer.GetNumFunctionCalls( );
+
 #ifdef PRINT_SCORES
                     wxPrintf("Current score is %g, from line %i\n", output_parameters.score, __LINE__);
 #endif
@@ -1755,6 +1763,11 @@ bool Refine3DApp::DoCalculation( ) {
         if ( calculate_matching_projections )
             final_image.Deallocate( );
         timer.lap("clean up");
+
+#pragma omp critical
+        {
+            number_of_calls_to_score_function += number_of_calls_to_score_function_local;
+        }
     } // end omp section
 
     if ( is_running_locally == true )
@@ -1778,6 +1791,7 @@ bool Refine3DApp::DoCalculation( ) {
 
     timer.print_times( );
     global_timer.print_times( );
+    wxPrintf("\nNumber of calls to scoring function %ld\n", number_of_calls_to_score_function);
 
     return true;
 }

--- a/src/programs/refine3d/refine3d_defines.h
+++ b/src/programs/refine3d/refine3d_defines.h
@@ -23,7 +23,7 @@ Note; this is a performance check and changes data movement.
 */
 ////////////////////////////////////////////////////////////
 
-// #define CALCULATE_SCORE_ON_CPU_DISABLE_GPU_PARTICLE
+#define CALCULATE_SCORE_ON_CPU_DISABLE_GPU_PARTICLE
 
 ////////////////////////////////////////////////////////////
 /*


### PR DESCRIPTION
# Description

Optimizes the whitenPS kernel to use more registers and thus fewer shared memory accesses. Also makes use of nv_bfloat16 + short as an intermediate storage type for the binned PS/counts. (fp32 and int used in arithmetic. The other speed up is from data locality, making a simple struct that holds a value and weight (though should probably be called value and count) for either

```cpp
__align(8)__ struct {
float value;
int weight;
}
```
or
```cpp
align(4)__ struct {
nv_bfloat16 value;
short weight;
}
```

Note nv_bfloat16 and not __half was used b/c (presumably) there was overflow. Should probably add some checks and/or enforce some better normalization after the forward FFT to reduce the magnitude of the values.
# Fixes 
 issue # (issue)

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [X] yes
- [ ] no

# These changes are isolated to the

- [ ] gui
- [ ] core library
- [X] gpu core library
- [X] program it modifies

# This build was done using the cistem_build_env docker container

- [X] yes
- [ ] no

# Checklist:

- [X] I have not changed anything that did not need to be changed
- [X] I have performed a self-review of my own code
- [X] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
