### PR TITLE
Extend gpu fft cap

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -745,6 +745,7 @@ if ENABLESAMPLES_AM
 if WANT_CISTEM_GPU_AM
         samples_functional_testing_SOURCES += programs/samples/1_cpu_gpu_comparison/resize_comparison.cpp programs/samples/1_cpu_gpu_comparison/projection_comparison.cpp programs/samples/1_cpu_gpu_comparison/masking.cpp programs/samples/1_cpu_gpu_comparison/statistical_ops.cpp 
         samples_functional_testing_SOURCES += programs/samples/3_tensor_ops/gpu_image_tensor_ops.cpp
+        samples_functional_testing_SOURCES += programs/samples/4_ffts/simple_cufft.cpp
 endif
 
 if WANT_CISTEM_GPU_AM 

--- a/src/core/cistem_constants.h
+++ b/src/core/cistem_constants.h
@@ -2,6 +2,7 @@
 #define _src_core_cistem_constants_h_
 
 #include <array>
+#include <string_view>
 
 // Place system wide constants and enums here. Gradually, we would like to replace the many defines.
 namespace cistem {
@@ -37,6 +38,19 @@ enum Enum : int { reference_volume_t,
                   ctf_image_t,
                   beamtilt_image_t };
 }
+
+namespace fft_type {
+// inplace/outofplace
+// input type
+// compute_type
+// output_type
+
+enum Enum : int { unset,
+                  inplace_32f_32f_32f,
+                  outofplace_32f_32f_32f };
+
+constexpr std::array<std::string_view, 3> names = {"unset", "inplace_32f_32f_32f", "outofplace_32f_32f_32f"};
+} // namespace fft_type
 
 namespace gpu {
 

--- a/src/core/cistem_constants.h
+++ b/src/core/cistem_constants.h
@@ -47,9 +47,15 @@ namespace fft_type {
 
 enum Enum : int { unset,
                   inplace_32f_32f_32f,
-                  outofplace_32f_32f_32f };
+                  outofplace_32f_32f_32f,
+                  inplace_32f_32f_32f_batched,
+                  outofplace_32f_32f_32f_batched };
 
-constexpr std::array<std::string_view, 3> names = {"unset", "inplace_32f_32f_32f", "outofplace_32f_32f_32f"};
+constexpr std::array<std::string_view, 5> names = {"unset",
+                                                   "inplace_32f_32f_32f",
+                                                   "outofplace_32f_32f_32f",
+                                                   "inplace_32f_32f_32f_batched",
+                                                   "outofplace_32f_32f_32f_batched"};
 } // namespace fft_type
 
 namespace gpu {
@@ -83,6 +89,25 @@ enum Enum : int {
 constexpr std::array<char, 4> tensor_names = {'A', 'B', 'C', 'D'};
 } // namespace tensor_id
 
+// valid as of cuda 11.7 from cufft.h definition of cufftResult_t
+constexpr std::array<std::string_view, 17> cufft_error_types = {
+        "CUFFT_SUCCESS",
+        "CUFFT_INVALID_PLAN",
+        "CUFFT_ALLOC_FAILED",
+        "CUFFT_INVALID_TYPE",
+        "CUFFT_INVALID_VALUE",
+        "CUFFT_INTERNAL_ERROR",
+        "CUFFT_EXEC_FAILED",
+        "CUFFT_SETUP_FAILED",
+        "CUFFT_INVALID_SIZE ",
+        "CUFFT_UNALIGNED_DATA",
+        "CUFFT_INCOMPLETE_PARAMETER_LIST",
+        "CUFFT_INVALID_DEVICE",
+        "CUFFT_PARSE_ERROR",
+        "CUFFT_NO_WORKSPACE",
+        "CUFFT_NOT_IMPLEMENTED",
+        "CUFFT_LICENSE_ERROR",
+        "CUFFT_NOT_SUPPORTED"};
 } // namespace gpu
 
 } // namespace cistem

--- a/src/core/image.cpp
+++ b/src/core/image.cpp
@@ -581,6 +581,9 @@ float Image::GetWeightedCorrelationWithImage(Image& projection_image, float low_
     int   i, j, k, pixel_counter;
     float x, y, z, frequency_squared;
     pixel_counter = 0;
+    int doing_it  = 0;
+    int doing_it2 = 0;
+    int doing_it3 = 0;
     for ( k = 0; k <= physical_upper_bound_complex_z; k++ ) {
         z = powf(ReturnFourierLogicalCoordGivenPhysicalCoord_Z(k) * fourier_voxel_size_z, 2);
         for ( j = 0; j <= physical_upper_bound_complex_y; j++ ) {
@@ -588,13 +591,15 @@ float Image::GetWeightedCorrelationWithImage(Image& projection_image, float low_
             for ( i = 0; i <= physical_upper_bound_complex_x; i++ ) {
                 x                 = powf(i * fourier_voxel_size_x, 2);
                 frequency_squared = x + y + z;
-                if ( frequency_squared >= low_limit2 && frequency_squared <= high_limit2 && (i > 1 && j > 1 && k > 1) ) {
+                doing_it3++;
+                if ( frequency_squared >= low_limit2 && frequency_squared <= high_limit2 && ! (i == 0 && j == 0 && k == 0) ) {
+                    doing_it++;
                     if ( (c_img[pixel_counter] == 0.f && c_img[pixel_counter + 1] == 0.0f) ||
                          (p_img[pixel_counter] == 0.f && p_img[pixel_counter + 1] == 0.0f) ) {
                         // Do nothing
                     }
                     else {
-
+                        doing_it2++;
                         sum1 += (powf(c_img[pixel_counter], 2) + powf(c_img[pixel_counter + 1], 2));
                         sum2 += (powf(p_img[pixel_counter], 2) + powf(p_img[pixel_counter + 1], 2));
                         if ( frequency_squared > signed_CC_limit2 ) {

--- a/src/core/stopwatch.cpp
+++ b/src/core/stopwatch.cpp
@@ -117,6 +117,35 @@ void StopWatch::mark_entry_or_exit_point(bool threadsafe) {
     }
 }
 
+float StopWatch::get_ratio_of_times(std::string event_1, std::string event_2, bool threadsafe) {
+    if ( threadsafe && ReturnThreadNumberOfCurrentThread( ) != 0 )
+        return;
+    bool  found_event_1 = false;
+    bool  found_event_2 = false;
+    float time_1;
+    float time_2;
+    for ( int i = 0; i < event_names.size( ); i++ ) {
+        if ( event_names[i] == event_1 ) {
+            time_1        = elapsed_times[i];
+            found_event_1 = true;
+        }
+        if ( event_names[i] == event_2 ) {
+            time_2        = elapsed_times[i];
+            found_event_2 = true;
+        }
+    }
+
+    if ( ! found_event_1 ) {
+        wxPrintf("Event 1 %s not found in Stopwatch at line %d in file %s\n", event_1.c_str( ), __LINE__, __FILE__);
+        exit(-1);
+    }
+    if ( ! found_event_2 ) {
+        wxPrintf("Event 2 %s not found in Stopwatch at line %d in file %s\n", event_2.c_str( ), __LINE__, __FILE__);
+        exit(-1);
+    }
+    return time_1 / time_2;
+}
+
 void StopWatch::start(std::string name, bool threadsafe) {
     // Typically we only want to track a single thread, which is default. Override this with threadsafe = false;
     if ( threadsafe && ReturnThreadNumberOfCurrentThread( ) != 0 )

--- a/src/core/stopwatch.h
+++ b/src/core/stopwatch.h
@@ -23,6 +23,8 @@ class StopWatch {
     inline void print_times(bool thread_safe = true) { return; }
 
     inline void mark_entry_or_exit_point(bool thread_safe = true) { return; }
+
+    inline void get_ratio_of_times(std::string event_1, std::string event_2, bool threadsafe = true) { return; }
 };
 
 } // namespace cistem_timer_noop
@@ -53,6 +55,8 @@ class StopWatch {
 
     // Start or pause the total elapsed time when passing a stopwatch pointer to a method. Place inside the method at the entry and exit point of the method call.
     void mark_entry_or_exit_point(bool thread_safe = true);
+
+    float get_ratio_of_times(std::string event_1, std::string event_2, bool threadsafe = true);
 
   private:
     enum TimeFormat : int { NANOSECONDS,

--- a/src/gpu/GpuImage.cu
+++ b/src/gpu/GpuImage.cu
@@ -10,6 +10,8 @@
 #include "gpu_core_headers.h"
 #include "GpuImage.h"
 #include "gpu_indexing_functions.h"
+#include "gpu_image_cuFFT_callbacks.h"
+
 // #define USE_ASYNC_MALLOC_FREE
 // #define USE_BLOCK_REDUCE
 #define USE_FP16_FOR_WHITENPS
@@ -52,94 +54,6 @@ __global__ void ClipIntoRealKernel(cufftReal* real_values_gpu,
                                    int3       other_physical_address_of_box_center,
                                    int3       wanted_coordinate_of_box_center,
                                    float      wanted_padding_value);
-
-// cuFFT callbacks
-__device__ cufftReal CB_ConvertInputf16Tof32(void* dataIn, size_t offset, void* callerInfo, void* sharedPtr);
-
-__device__ cufftReal CB_ConvertInputf16Tof32(void* dataIn, size_t offset, void* callerInfo, void* sharedPtr) {
-
-    const __half element = ((__half*)dataIn)[offset];
-    return (cufftReal)(__half2float(element));
-}
-
-__device__ cufftCallbackLoadR d_ConvertInputf16Tof32Ptr = CB_ConvertInputf16Tof32;
-
-__device__ void CB_scaleFFTAndStore(void* dataOut, size_t offset, cufftComplex element, void* callerInfo, void* sharedPtr);
-
-__device__ void CB_scaleFFTAndStore(void* dataOut, size_t offset, cufftComplex element, void* callerInfo, void* sharedPtr) {
-    float scale_factor = *(float*)callerInfo;
-
-    ((cufftComplex*)dataOut)[offset] = (cufftComplex)ComplexScale(element, scale_factor);
-}
-
-//__device__ cufftCallbackLoadR d_ConvertInputf16Tof32Ptr = CB_ConvertInputf16Tof32;
-__device__ cufftCallbackStoreC d_scaleFFTAndStorePtr = CB_scaleFFTAndStore;
-
-__device__ void CB_mipCCGAndStore(void* dataOut, size_t offset, cufftReal element, void* callerInfo, void* sharedPtr);
-
-__device__ void CB_mipCCGAndStore(void* dataOut, size_t offset, cufftReal element, void* callerInfo, void* sharedPtr) {
-
-    __half* data_out_half = (__half*)callerInfo;
-    //	data_out_half[offset] = __float2half(element);
-    //	((cufftReal *)dataOut)[offset] = element;
-
-#ifdef DISABLECACHEHINTS
-    ((__half*)data_out_half)[offset] = __float2half(element);
-#else
-    __stcs(&data_out_half[offset], __float2half(element));
-#endif
-
-    //	)_(dataOut)[offset] = __float2half(element);
-    //
-}
-
-__device__ cufftCallbackStoreR d_mipCCGAndStorePtr = CB_mipCCGAndStore;
-
-template <typename T>
-struct CB_complexConjMulLoad_params {
-    T*    target;
-    float scale;
-};
-
-static __device__ cufftComplex CB_complexConjMulLoad_32f(void* dataIn, size_t offset, void* callerInfo, void* sharedPtr);
-static __device__ cufftComplex CB_complexConjMulLoad_16f(void* dataIn, size_t offset, void* callerInfo, void* sharedPtr);
-
-static __device__ cufftComplex CB_complexConjMulLoad_32f(void* dataIn, size_t offset, void* callerInfo, void* sharedPtr) {
-    CB_complexConjMulLoad_params<cufftComplex>* my_params = (CB_complexConjMulLoad_params<cufftComplex>*)callerInfo;
-    return (cufftComplex)ComplexConjMulAndScale(my_params->target[offset], ((Complex*)dataIn)[offset], my_params->scale);
-    //    return (cufftComplex)make_float2(my_params->scale * __fmaf_rn(my_params->target[offset].x ,  ((Complex *)dataIn)[offset].x, my_params->target[offset].y * ((Complex *)dataIn)[offset].y),
-    //    		my_params->scale * __fmaf_rn(my_params->target[offset].y , -((Complex *)dataIn)[offset].x, my_params->target[offset].x * ((Complex *)dataIn)[offset].y));
-}
-
-static __device__ cufftComplex CB_complexConjMulLoad_16f(void* dataIn, size_t offset, void* callerInfo, void* sharedPtr) {
-    CB_complexConjMulLoad_params<__half2>* my_params = (CB_complexConjMulLoad_params<__half2>*)callerInfo;
-    return (cufftComplex)ComplexConjMulAndScale((cufftComplex)__half22float2(my_params->target[offset]), ((Complex*)dataIn)[offset], my_params->scale);
-}
-
-__device__ cufftCallbackLoadC d_complexConjMulLoad_32f = CB_complexConjMulLoad_32f;
-__device__ cufftCallbackLoadC d_complexConjMulLoad_16f = CB_complexConjMulLoad_16f;
-
-typedef struct _CB_realLoadAndClipInto_params {
-    int*       mask;
-    cufftReal* target;
-
-} CB_realLoadAndClipInto_params;
-
-static __device__ cufftReal CB_realLoadAndClipInto(void* dataIn, size_t offset, void* callerInfo, void* sharedPtr);
-
-static __device__ cufftReal CB_realLoadAndClipInto(void* dataIn, size_t offset, void* callerInfo, void* sharedPtr) {
-
-    CB_realLoadAndClipInto_params* my_params = (CB_realLoadAndClipInto_params*)callerInfo;
-    int                            idx       = my_params->mask[offset];
-    if ( idx == 0 ) {
-        return 0.0f;
-    }
-    else {
-        return my_params->target[idx];
-    }
-}
-
-__device__ cufftCallbackLoadR d_realLoadAndClipInto = CB_realLoadAndClipInto;
 
 // Inline declarations
 __device__ __forceinline__ int
@@ -689,11 +603,11 @@ void GpuImage::BufferInit(BufferType bt, int n_elements) {
         case b_16f:
             if ( ! is_allocated_16f_buffer ) {
 #ifdef USE_ASYNC_MALLOC_FREE
-                cudaErr(cudaMallocAsync(&real_values_16f, sizeof(__half) * real_memory_allocated, cudaStreamPerThread));
+                cudaErr(cudaMallocAsync(&real_values_16f, size_of_half * real_memory_allocated, cudaStreamPerThread));
 #else
-                cudaErr(cudaMalloc(&real_values_16f, sizeof(__half) * real_memory_allocated));
+                cudaErr(cudaMalloc(&real_values_16f, size_of_half * real_memory_allocated));
 #endif
-                complex_values_16f      = (__half2*)real_values_16f;
+                complex_values_16f      = (void*)real_values_16f;
                 is_allocated_16f_buffer = true;
             }
             break;
@@ -720,11 +634,11 @@ void GpuImage::BufferInit(BufferType bt, int n_elements) {
             if ( ! is_allocated_ctf_16f_buffer ) {
                 MyDebugAssertTrue(n_elements > 0, "For allocating the ctf_16f buffer, you must specify the number of elements");
 #ifdef USE_ASYNC_MALLOC_FREE
-                cudaErr(cudaMallocAsync(&ctf_buffer_16f, sizeof(__half) * n_elements, cudaStreamPerThread));
+                cudaErr(cudaMallocAsync(&ctf_buffer_16f, size_of_half * n_elements, cudaStreamPerThread));
 #else
-                cudaErr(cudaMalloc(&ctf_buffer_16f, sizeof(__half) * n_elements));
+                cudaErr(cudaMalloc(&ctf_buffer_16f, size_of_half * n_elements));
 #endif
-                ctf_complex_buffer_16f      = (__half2*)ctf_buffer_16f;
+                ctf_complex_buffer_16f      = (void*)ctf_buffer_16f;
                 is_allocated_ctf_16f_buffer = true;
             }
             break;
@@ -1913,7 +1827,7 @@ Peak GpuImage::FindPeakAtOriginFast2D(int wanted_max_pix_x, int wanted_max_pix_y
     Peak* device_peak;
     cudaErr(cudaMalloc(&device_peak, sizeof(Peak)));
 
-        if ( wanted_max_pix_x > dims.x / 2 )
+    if ( wanted_max_pix_x > dims.x / 2 )
         wanted_max_pix_x = dims.x / 2;
     if ( wanted_max_pix_y > dims.y / 2 )
         wanted_max_pix_y = dims.y / 2;
@@ -1926,7 +1840,7 @@ Peak GpuImage::FindPeakAtOriginFast2D(int wanted_max_pix_x, int wanted_max_pix_y
 
     if ( load_half_precision ) {
         precheck;
-        FindPeakAtOriginFast2DKernel<<<gd, tpb, 0, cudaStreamPerThread>>>(real_values_16f, device_peak, wanted_max_pix_x, wanted_max_pix_y, dims.x, dims.y, dims.w);
+        FindPeakAtOriginFast2DKernel<<<gd, tpb, 0, cudaStreamPerThread>>>(real_values_fp16, device_peak, wanted_max_pix_x, wanted_max_pix_y, dims.x, dims.y, dims.w);
         postcheck;
     }
     else {
@@ -3351,11 +3265,11 @@ void GpuImage::ConvertToHalfPrecision(bool deallocate_single_precision) {
     precheck;
     if ( is_in_real_space ) {
         ReturnLaunchParameters(dims, true);
-        ConvertToHalfPrecisionKernelReal<<<gridDims, threadsPerBlock, 0, cudaStreamPerThread>>>(real_values_gpu, real_values_16f, this->dims);
+        ConvertToHalfPrecisionKernelReal<<<gridDims, threadsPerBlock, 0, cudaStreamPerThread>>>(real_values_gpu, real_values_fp16, this->dims);
     }
     else {
         ReturnLaunchParameters(dims, false);
-        ConvertToHalfPrecisionKernelComplex<<<gridDims, threadsPerBlock, 0, cudaStreamPerThread>>>(complex_values_gpu, complex_values_16f, this->dims, this->physical_upper_bound_complex);
+        ConvertToHalfPrecisionKernelComplex<<<gridDims, threadsPerBlock, 0, cudaStreamPerThread>>>(complex_values_gpu, complex_values_fp16, this->dims, this->physical_upper_bound_complex);
     }
     postcheck;
 

--- a/src/gpu/GpuImage.cu
+++ b/src/gpu/GpuImage.cu
@@ -2529,7 +2529,7 @@ void GpuImage::_ForwardFFT( ) {
 
 template <>
 void GpuImage::_ForwardFFT<float, float2>( ) {
-    cudaErr(cufftExecR2C(cuda_plan_forward, (cufftReal*)position_space_ptr, (cufftComplex*)momentum_space_ptr));
+    cufftErr(cufftExecR2C(cuda_plan_forward, (cufftReal*)position_space_ptr, (cufftComplex*)momentum_space_ptr));
 }
 
 void GpuImage::ForwardFFTBatched(bool should_scale) {
@@ -2566,7 +2566,7 @@ void GpuImage::ForwardFFT(bool should_scale) {
     if ( is_half_precision && ! is_set_convertInputf16Tof32 ) {
         cufftCallbackLoadR h_ConvertInputf16Tof32Ptr;
         cudaErr(cudaMemcpyFromSymbol(&h_ConvertInputf16Tof32Ptr, d_ConvertInputf16Tof32Ptr, sizeof(h_ConvertInputf16Tof32Ptr)));
-        cudaErr(cufftXtSetCallback(cuda_plan_forward, (void**)&h_ConvertInputf16Tof32Ptr, CUFFT_CB_LD_REAL, 0));
+        cufftErr(cufftXtSetCallback(cuda_plan_forward, (void**)&h_ConvertInputf16Tof32Ptr, CUFFT_CB_LD_REAL, 0));
         is_set_convertInputf16Tof32 = true;
         //	  cudaErr(cudaFree(norm_factor));
         //	  this->MultiplyByConstant(ft_normalization_factor*ft_normalization_factor);
@@ -2631,7 +2631,7 @@ void GpuImage::ForwardFFTAndClipInto(GpuImage& image_to_insert, bool should_scal
         cudaErr(cudaMemcpyFromSymbol(&h_realLoadAndClipInto, d_realLoadAndClipInto, sizeof(h_realLoadAndClipInto)));
         cudaErr(cudaStreamSynchronize(cudaStreamPerThread));
 
-        cudaErr(cufftXtSetCallback(cuda_plan_forward, (void**)&h_realLoadAndClipInto, CUFFT_CB_LD_REAL, (void**)&d_params));
+        cufftErr(cufftXtSetCallback(cuda_plan_forward, (void**)&h_realLoadAndClipInto, CUFFT_CB_LD_REAL, (void**)&d_params));
         is_set_realLoadAndClipInto = true;
 
         //	  cudaErr(cudaFree(norm_factor));
@@ -2656,7 +2656,7 @@ void GpuImage::ForwardFFTAndClipInto(GpuImage& image_to_insert, bool should_scal
 
 template <>
 void GpuImage::_BackwardFFT<float, float2>( ) {
-    cudaErr(cufftExecC2R(cuda_plan_inverse, (cufftComplex*)momentum_space_ptr, (cufftReal*)position_space_ptr));
+    cufftErr(cufftExecC2R(cuda_plan_inverse, (cufftComplex*)momentum_space_ptr, (cufftReal*)position_space_ptr));
 }
 
 void GpuImage::BackwardFFT( ) {
@@ -2709,9 +2709,9 @@ void GpuImage::BackwardFFTAfterComplexConjMul(T* image_to_multiply, bool load_ha
 
         cudaErr(cudaMemcpyFromSymbol(&h_mipCCGStore, d_mipCCGAndStorePtr, sizeof(h_mipCCGStore)));
         cudaErr(cudaStreamSynchronize(cudaStreamPerThread));
-        cudaErr(cufftXtSetCallback(cuda_plan_inverse, (void**)&h_complexConjMulLoad, CUFFT_CB_LD_COMPLEX, (void**)&d_params));
+        cufftErr(cufftXtSetCallback(cuda_plan_inverse, (void**)&h_complexConjMulLoad, CUFFT_CB_LD_COMPLEX, (void**)&d_params));
         //		void** fake_params;real_values_16f
-        cudaErr(cufftXtSetCallback(cuda_plan_inverse, (void**)&h_mipCCGStore, CUFFT_CB_ST_REAL, (void**)&real_values_16f));
+        cufftErr(cufftXtSetCallback(cuda_plan_inverse, (void**)&h_mipCCGStore, CUFFT_CB_ST_REAL, (void**)&real_values_16f));
 
         //		d_complexConjMulLoad;
         is_set_complexConjMulLoad = true;
@@ -3187,11 +3187,11 @@ void GpuImage::SetCufftPlan(cistem::fft_type::Enum plan_type, void* input_buffer
     long long int  iDist;
     long long int  oDist;
 
-    cudaErr(cufftCreate(&cuda_plan_forward));
-    cudaErr(cufftCreate(&cuda_plan_inverse));
+    cufftErr(cufftCreate(&cuda_plan_forward));
+    cufftErr(cufftCreate(&cuda_plan_inverse));
 
-    cudaErr(cufftSetStream(cuda_plan_forward, cudaStreamPerThread));
-    cudaErr(cufftSetStream(cuda_plan_inverse, cudaStreamPerThread));
+    cufftErr(cufftSetStream(cuda_plan_forward, cudaStreamPerThread));
+    cufftErr(cufftSetStream(cuda_plan_inverse, cudaStreamPerThread));
 
     if ( dims.z > 1 && cufft_batch_size == 1 ) {
         rank     = 3;
@@ -3275,15 +3275,6 @@ void GpuImage::SetCufftPlan(cistem::fft_type::Enum plan_type, void* input_buffer
     // }
     // else {
 
-    std::cerr << "FFT plan type " << cistem::fft_type::names[plan_type] << "\n";
-    std::cerr << "inembed " << inembed[0] << " " << inembed[1] << "\n";
-    std::cerr << "onembed " << onembed[0] << " " << onembed[1] << "\n";
-    std::cerr << "iDist " << iDist << "\n";
-    std::cerr << "oDist " << oDist << "\n";
-    std::cerr << "iStride " << iStride << "\n";
-    std::cerr << "oStride " << oStride << "\n";
-    std::cerr << "iBatch " << cufft_batch_size << "\n";
-
     cufftErr(cufftXtMakePlanMany(cuda_plan_forward, rank, ifftDims,
                                  inembed, iStride, iDist,
                                  CUDA_R_32F,
@@ -3292,13 +3283,13 @@ void GpuImage::SetCufftPlan(cistem::fft_type::Enum plan_type, void* input_buffer
                                  cufft_batch_size, &cuda_plan_worksize_forward,
                                  CUDA_C_32F));
 
-    cufftErr(cufftXtMakePlanMany(cuda_plan_inverse, rank, offtDims,
+    cufftErr(cufftXtMakePlanMany(cuda_plan_inverse, rank, ifftDims,
                                  onembed, oStride, oDist,
                                  CUDA_C_32F,
                                  inembed, iStride, iDist,
-                                 CUDA_C_32F,
+                                 CUDA_R_32F,
                                  cufft_batch_size, &cuda_plan_worksize_inverse,
-                                 CUDA_R_32F));
+                                 CUDA_C_32F));
 
     delete[] ifftDims;
     delete[] offtDims;
@@ -3338,8 +3329,8 @@ void GpuImage::Deallocate( ) {
     BufferDestroy( );
 
     if ( set_plan_type != cistem::fft_type::Enum::unset ) {
-        cudaErr(cufftDestroy(cuda_plan_inverse));
-        cudaErr(cufftDestroy(cuda_plan_forward));
+        cufftErr(cufftDestroy(cuda_plan_inverse));
+        cufftErr(cufftDestroy(cuda_plan_forward));
         set_plan_type             = cistem::fft_type::Enum::unset;
         cufft_batch_size          = 1;
         is_set_complexConjMulLoad = false;

--- a/src/gpu/GpuImage.cu
+++ b/src/gpu/GpuImage.cu
@@ -2523,6 +2523,15 @@ void GpuImage::CopyVolumeDeviceToHost(bool free_gpu_memory, bool unpin_host_memo
     }
 }
 
+template <class InputType, class OutputType>
+void GpuImage::_ForwardFFT( ) {
+}
+
+template <>
+void GpuImage::_ForwardFFT<float, float2>( ) {
+    cudaErr(cufftExecR2C(cuda_plan_forward, (cufftReal*)position_space_ptr, (cufftComplex*)momentum_space_ptr));
+}
+
 void GpuImage::ForwardFFT(bool should_scale) {
 
     bool is_half_precision = false;
@@ -2530,9 +2539,7 @@ void GpuImage::ForwardFFT(bool should_scale) {
     MyDebugAssertTrue(is_in_memory_gpu, "Gpu memory not allocated");
     MyDebugAssertTrue(is_in_real_space, "Image alread in Fourier space");
 
-    if ( ! is_fft_planned ) {
-        SetCufftPlan( );
-    }
+    SetCufftPlan(cistem::fft_type::Enum::inplace_32f_32f_32f, (void*)real_values_gpu, (void*)complex_values_gpu);
 
     // For reference to clear cufftXtClearCallback(cufftHandle lan, cufftXtCallbackType type);
     if ( is_half_precision && ! is_set_convertInputf16Tof32 ) {
@@ -2564,7 +2571,8 @@ void GpuImage::ForwardFFT(bool should_scale) {
     //	BufferInit(b_image);
     //    cudaErr(cufftExecR2C(this->cuda_plan_forward, (cufftReal*)real_values_gpu, (cufftComplex*)image_buffer->complex_values));
 
-    cudaErr(cufftExecR2C(this->cuda_plan_forward, (cufftReal*)real_values_gpu, (cufftComplex*)complex_values_gpu));
+    _ForwardFFT<float, float2>( );
+    // cudaErr(cufftExecR2C(this->cuda_plan_forward, position_space_ptr, momentum_space_ptr));
 
     is_in_real_space                 = false;
     host_image_ptr->is_in_real_space = false;
@@ -2578,9 +2586,7 @@ void GpuImage::ForwardFFTAndClipInto(GpuImage& image_to_insert, bool should_scal
     MyDebugAssertTrue(is_in_real_space, "Image alread in Fourier space");
     MyDebugAssertTrue(image_to_insert.is_in_real_space, "I in image to insert alread in Fourier space");
 
-    if ( ! is_fft_planned ) {
-        SetCufftPlan( );
-    }
+    SetCufftPlan(cistem::fft_type::Enum::inplace_32f_32f_32f, (void*)real_values_gpu, (void*)complex_values_gpu);
 
     // For reference to clear cufftXtClearCallback(cufftHandle lan, cufftXtCallbackType type);
     if ( ! is_set_realLoadAndClipInto ) {
@@ -2617,7 +2623,9 @@ void GpuImage::ForwardFFTAndClipInto(GpuImage& image_to_insert, bool should_scal
     //	BufferInit(b_image);
     //    cudaErr(cufftExecR2C(this->cuda_plan_forward, (cufftReal*)real_values_gpu, (cufftComplex*)image_buffer->complex_values));
 
-    cudaErr(cufftExecR2C(this->cuda_plan_forward, (cufftReal*)real_values_gpu, (cufftComplex*)complex_values_gpu));
+    _ForwardFFT<float, float2>( );
+
+    // cudaErr(cufftExecR2C(this->cuda_plan_forward, position_space_ptr, momentum_space_ptr));
 
     is_in_real_space                 = false;
     host_image_ptr->is_in_real_space = false;
@@ -2625,19 +2633,23 @@ void GpuImage::ForwardFFTAndClipInto(GpuImage& image_to_insert, bool should_scal
     npp_ROI = npp_ROI_fourier_space;
 }
 
+template <>
+void GpuImage::_BackwardFFT<float, float2>( ) {
+    cudaErr(cufftExecC2R(cuda_plan_inverse, (cufftComplex*)momentum_space_ptr, (cufftReal*)position_space_ptr));
+}
+
 void GpuImage::BackwardFFT( ) {
 
     MyDebugAssertTrue(is_in_memory_gpu, "Gpu memory not allocated");
     MyDebugAssertFalse(is_in_real_space, "Image is already in real space");
 
-    if ( ! is_fft_planned ) {
-        SetCufftPlan( );
-    }
+    SetCufftPlan(cistem::fft_type::Enum::inplace_32f_32f_32f, (void*)real_values_gpu, (void*)complex_values_gpu);
 
     //  BufferInit(b_image);
     //  cudaErr(cufftExecC2R(this->cuda_plan_inverse, (cufftComplex*)image_buffer->complex_values, (cufftReal*)real_values_gpu));
 
-    cudaErr(cufftExecC2R(this->cuda_plan_inverse, (cufftComplex*)complex_values_gpu, (cufftReal*)real_values_gpu));
+    _BackwardFFT<float, float2>( );
+    // cudaErr(cufftExecC2R(this->cuda_plan_inverse, momentum_space_ptr, position_space_ptr));
 
     is_in_real_space                 = true;
     host_image_ptr->is_in_real_space = true;
@@ -2652,9 +2664,8 @@ void GpuImage::BackwardFFTAfterComplexConjMul(T* image_to_multiply, bool load_ha
     MyDebugAssertFalse(is_in_real_space, "Image is already in real space");
     MyDebugAssertTrue(load_half_precision ? is_allocated_16f_buffer : true, "FP16 memory is not allocated, but is requested.");
 
-    if ( ! is_fft_planned ) {
-        SetCufftPlan( );
-    }
+    SetCufftPlan(cistem::fft_type::Enum::inplace_32f_32f_32f, (void*)real_values_gpu, (void*)complex_values_gpu);
+
     if ( ! is_set_complexConjMulLoad ) {
         cufftCallbackStoreC              h_complexConjMulLoad;
         cufftCallbackStoreR              h_mipCCGStore;
@@ -2688,7 +2699,8 @@ void GpuImage::BackwardFFTAfterComplexConjMul(T* image_to_multiply, bool load_ha
     //  BufferInit(b_image);
     //  cudaErr(cufftExecC2R(this->cuda_plan_inverse, (cufftComplex*)image_buffer->complex_values, (cufftReal*)real_values_gpu));
 
-    cudaErr(cufftExecC2R(this->cuda_plan_inverse, (cufftComplex*)complex_values_gpu, (cufftReal*)real_values_gpu));
+    _BackwardFFT<float, float2>( );
+    // cudaErr(cufftExecC2R(this->cuda_plan_inverse, momentum_space_ptr, position_space_ptr));
 
     is_in_real_space                 = true;
     host_image_ptr->is_in_real_space = true;
@@ -3113,7 +3125,32 @@ void GpuImage::QuickAndDirtyWriteSlices(std::string filename, int first_slice, i
     buffer_img.Deallocate( );
 }
 
-void GpuImage::SetCufftPlan(bool use_half_precision) {
+void GpuImage::SetCufftPlan(cistem::fft_type::Enum plan_type, void* input_buffer, void* output_buffer) {
+
+    // We need to set the appropriate pointer types for the requested plan.
+    // We also want to record the type of plan requested to see if re-planning is necessary.
+    using ft = cistem::fft_type::Enum;
+
+    if ( plan_type == set_plan_type ) {
+        // We are good to go.
+        return;
+    }
+    else {
+        // We need to re-plan.
+        switch ( plan_type ) {
+            case ft::inplace_32f_32f_32f: {
+                position_space_ptr = reinterpret_cast<cufftReal*>(input_buffer);
+                momentum_space_ptr = reinterpret_cast<cufftComplex*>(output_buffer);
+                break;
+            }
+            default: {
+                std::cerr << "Want to set plan type " << cistem::fft_type::names[plan_type] << "\n";
+                MyDebugAssertTrue(false, "Unsupported plan type");
+                break;
+            }
+        }
+    }
+
     int            rank;
     long long int* fftDims;
     long long int* inembed;
@@ -3175,35 +3212,42 @@ void GpuImage::SetCufftPlan(bool use_half_precision) {
     // As far as I can tell, the padded layout must be assumed and onembed/inembed
     // are not needed. TODO ask John about this.
 
-    if ( use_half_precision ) {
-        cudaErr(cufftXtMakePlanMany(cuda_plan_forward, rank, fftDims,
-                                    NULL, NULL, NULL, CUDA_R_16F,
-                                    NULL, NULL, NULL, CUDA_C_16F, iBatch, &cuda_plan_worksize_forward, CUDA_C_16F));
-        cudaErr(cufftXtMakePlanMany(cuda_plan_inverse, rank, fftDims,
-                                    NULL, NULL, NULL, CUDA_C_16F,
-                                    NULL, NULL, NULL, CUDA_R_16F, iBatch, &cuda_plan_worksize_inverse, CUDA_R_16F));
-    }
-    else {
-        cudaErr(cufftXtMakePlanMany(cuda_plan_forward, rank, fftDims,
-                                    NULL, NULL, NULL, CUDA_R_32F,
-                                    NULL, NULL, NULL, CUDA_C_32F, iBatch, &cuda_plan_worksize_forward, CUDA_C_32F));
-        cudaErr(cufftXtMakePlanMany(cuda_plan_inverse, rank, fftDims,
-                                    NULL, NULL, NULL, CUDA_C_32F,
-                                    NULL, NULL, NULL, CUDA_R_32F, iBatch, &cuda_plan_worksize_inverse, CUDA_R_32F));
-    }
+    // if ( use_half_precision ) {
+    //     cudaErr(cufftXtMakePlanMany(cuda_plan_forward, rank, fftDims,
+    //                                 NULL, NULL, NULL, CUDA_R_16F,
+    //                                 NULL, NULL, NULL, CUDA_C_16F, iBatch, &cuda_plan_worksize_forward, CUDA_C_16F));
+    //     cudaErr(cufftXtMakePlanMany(cuda_plan_inverse, rank, fftDims,
+    //                                 NULL, NULL, NULL, CUDA_C_16F,
+    //                                 NULL, NULL, NULL, CUDA_R_16F, iBatch, &cuda_plan_worksize_inverse, CUDA_R_16F));
+    // }
+    // else {
+    cudaErr(cufftXtMakePlanMany(cuda_plan_forward, rank, fftDims,
+                                NULL, NULL, NULL,
+                                CUDA_R_32F,
+                                NULL, NULL, NULL,
+                                CUDA_C_32F,
+                                iBatch, &cuda_plan_worksize_forward,
+                                CUDA_C_32F));
 
-    //    cufftPlanMany(&dims.cuda_plan_forward, rank, fftDims,
-    //                  inembed, iStride, iDist,
-    //                  onembed, oStride, oDist, CUFFT_R2C, iBatch);
-    //    cufftPlanMany(&dims.cuda_plan_inverse, rank, fftDims,
-    //                  onembed, oStride, oDist,
-    //                  inembed, iStride, iDist, CUFFT_C2R, iBatch);
+    cudaErr(cufftXtMakePlanMany(cuda_plan_inverse, rank, fftDims,
+                                NULL, NULL, NULL,
+                                CUDA_C_32F,
+                                NULL, NULL, NULL,
+                                CUDA_R_32F,
+                                iBatch, &cuda_plan_worksize_inverse,
+                                CUDA_R_32F));
+    // }
+
+    // //    cufftPlanMany(&dims.cuda_plan_forward, rank, fftDims,
+    // //                  inembed, iStride, iDist,
+    // //                  onembed, oStride, oDist, CUFFT_R2C, iBatch);
+    // //    cufftPlanMany(&dims.cuda_plan_inverse, rank, fftDims,
+    // //                  onembed, oStride, oDist,
+    // //                  inembed, iStride, iDist, CUFFT_C2R, iBatch);
 
     delete[] fftDims;
     delete[] inembed;
     delete[] onembed;
-
-    is_fft_planned = true;
 }
 
 void GpuImage::Deallocate( ) {
@@ -3237,10 +3281,10 @@ void GpuImage::Deallocate( ) {
     // Separat method for all the buffer memory spaces, not sure it this makes sense
     BufferDestroy( );
 
-    if ( is_fft_planned ) {
+    if ( set_plan_type != cistem::fft_type::Enum::unset ) {
         cudaErr(cufftDestroy(cuda_plan_inverse));
         cudaErr(cufftDestroy(cuda_plan_forward));
-        is_fft_planned            = false;
+        set_plan_type             = cistem::fft_type::Enum::unset;
         is_set_complexConjMulLoad = false;
     }
 
@@ -3407,7 +3451,7 @@ void GpuImage::UpdateBoolsToDefault( ) {
     is_host_memory_pinned = false;
 
     // libraries
-    is_fft_planned = false;
+    set_plan_type = cistem::fft_type::Enum::unset;
     //	is_cublas_loaded = false;
     is_npp_loaded = false;
 
@@ -3842,7 +3886,7 @@ void GpuImage::Consume(GpuImage* other_image) {
 
     cuda_plan_forward = other_image->cuda_plan_forward;
     cuda_plan_inverse = other_image->cuda_plan_inverse;
-    is_fft_planned    = other_image->is_fft_planned;
+    set_plan_type     = other_image->set_plan_type;
 
     // We neeed to override the other image pointers so that it doesn't deallocate the memory.
     other_image->real_values_gpu    = NULL;
@@ -3851,7 +3895,7 @@ void GpuImage::Consume(GpuImage* other_image) {
 
     other_image->cuda_plan_forward = NULL;
     other_image->cuda_plan_inverse = NULL;
-    other_image->is_fft_planned    = false;
+    other_image->set_plan_type     = cistem::fft_type::Enum::unset;
 
     return;
 }

--- a/src/gpu/GpuImage.cu
+++ b/src/gpu/GpuImage.cu
@@ -2548,9 +2548,10 @@ void GpuImage::ForwardFFTBatched(bool should_scale) {
     _ForwardFFT<float, float2>( );
     // cudaErr(cufftExecR2C(this->cuda_plan_forward, position_space_ptr, momentum_space_ptr));
 
-    is_in_real_space                 = false;
-    host_image_ptr->is_in_real_space = false;
-    npp_ROI                          = npp_ROI_fourier_space;
+    is_in_real_space = false;
+    if ( host_image_ptr )
+        host_image_ptr->is_in_real_space = false;
+    npp_ROI = npp_ROI_fourier_space;
 }
 
 void GpuImage::ForwardFFT(bool should_scale) {
@@ -2595,9 +2596,10 @@ void GpuImage::ForwardFFT(bool should_scale) {
     _ForwardFFT<float, float2>( );
     // cudaErr(cufftExecR2C(this->cuda_plan_forward, position_space_ptr, momentum_space_ptr));
 
-    is_in_real_space                 = false;
-    host_image_ptr->is_in_real_space = false;
-    npp_ROI                          = npp_ROI_fourier_space;
+    is_in_real_space = false;
+    if ( host_image_ptr )
+        host_image_ptr->is_in_real_space = false;
+    npp_ROI = npp_ROI_fourier_space;
 }
 
 void GpuImage::ForwardFFTAndClipInto(GpuImage& image_to_insert, bool should_scale) {
@@ -2648,8 +2650,9 @@ void GpuImage::ForwardFFTAndClipInto(GpuImage& image_to_insert, bool should_scal
 
     // cudaErr(cufftExecR2C(this->cuda_plan_forward, position_space_ptr, momentum_space_ptr));
 
-    is_in_real_space                 = false;
-    host_image_ptr->is_in_real_space = false;
+    is_in_real_space = false;
+    if ( host_image_ptr )
+        host_image_ptr->is_in_real_space = false;
 
     npp_ROI = npp_ROI_fourier_space;
 }
@@ -2672,8 +2675,9 @@ void GpuImage::BackwardFFT( ) {
     _BackwardFFT<float, float2>( );
     // cudaErr(cufftExecC2R(this->cuda_plan_inverse, momentum_space_ptr, position_space_ptr));
 
-    is_in_real_space                 = true;
-    host_image_ptr->is_in_real_space = true;
+    is_in_real_space = true;
+    if ( host_image_ptr )
+        host_image_ptr->is_in_real_space = true;
 
     npp_ROI = npp_ROI_real_space;
 }
@@ -2724,6 +2728,7 @@ void GpuImage::BackwardFFTAfterComplexConjMul(T* image_to_multiply, bool load_ha
     // cudaErr(cufftExecC2R(this->cuda_plan_inverse, momentum_space_ptr, position_space_ptr));
 
     is_in_real_space                 = true;
+    if ( host_image_ptr )
     host_image_ptr->is_in_real_space = true;
     npp_ROI                          = npp_ROI_real_space;
 }

--- a/src/gpu/GpuImage.cu
+++ b/src/gpu/GpuImage.cu
@@ -2355,9 +2355,8 @@ void GpuImage::CopyDeviceToHost(bool free_gpu_memory, bool unpin_host_memory) {
 
     MyDebugAssertTrue(is_in_memory_gpu, "GPU memory not allocated");
     // TODO other asserts on size etc.
-    precheck;
+
     cudaErr(cudaMemcpyAsync(pinnedPtr, real_values_gpu, real_memory_allocated * sizeof(float), cudaMemcpyDeviceToHost, cudaStreamPerThread));
-    postcheck;
     //  cudaErr(cudaMemcpyAsync(real_values, real_values_gpu, real_memory_allocated*sizeof(float),cudaMemcpyDeviceToHost,cudaStreamPerThread));
     // TODO add asserts etc.
     if ( free_gpu_memory ) {
@@ -2567,8 +2566,9 @@ void GpuImage::ForwardFFT(bool should_scale) {
 
     cudaErr(cufftExecR2C(this->cuda_plan_forward, (cufftReal*)real_values_gpu, (cufftComplex*)complex_values_gpu));
 
-    is_in_real_space = false;
-    npp_ROI          = npp_ROI_fourier_space;
+    is_in_real_space                 = false;
+    host_image_ptr->is_in_real_space = false;
+    npp_ROI                          = npp_ROI_fourier_space;
 }
 
 void GpuImage::ForwardFFTAndClipInto(GpuImage& image_to_insert, bool should_scale) {
@@ -2619,8 +2619,10 @@ void GpuImage::ForwardFFTAndClipInto(GpuImage& image_to_insert, bool should_scal
 
     cudaErr(cufftExecR2C(this->cuda_plan_forward, (cufftReal*)real_values_gpu, (cufftComplex*)complex_values_gpu));
 
-    is_in_real_space = false;
-    npp_ROI          = npp_ROI_fourier_space;
+    is_in_real_space                 = false;
+    host_image_ptr->is_in_real_space = false;
+
+    npp_ROI = npp_ROI_fourier_space;
 }
 
 void GpuImage::BackwardFFT( ) {
@@ -2637,8 +2639,10 @@ void GpuImage::BackwardFFT( ) {
 
     cudaErr(cufftExecC2R(this->cuda_plan_inverse, (cufftComplex*)complex_values_gpu, (cufftReal*)real_values_gpu));
 
-    is_in_real_space = true;
-    npp_ROI          = npp_ROI_real_space;
+    is_in_real_space                 = true;
+    host_image_ptr->is_in_real_space = true;
+
+    npp_ROI = npp_ROI_real_space;
 }
 
 template <typename T>
@@ -2686,8 +2690,9 @@ void GpuImage::BackwardFFTAfterComplexConjMul(T* image_to_multiply, bool load_ha
 
     cudaErr(cufftExecC2R(this->cuda_plan_inverse, (cufftComplex*)complex_values_gpu, (cufftReal*)real_values_gpu));
 
-    is_in_real_space = true;
-    npp_ROI          = npp_ROI_real_space;
+    is_in_real_space                 = true;
+    host_image_ptr->is_in_real_space = true;
+    npp_ROI                          = npp_ROI_real_space;
 }
 
 template void GpuImage::BackwardFFTAfterComplexConjMul(__half2* image_to_multiply, bool load_half_precision);

--- a/src/gpu/GpuImage.cu
+++ b/src/gpu/GpuImage.cu
@@ -2532,6 +2532,27 @@ void GpuImage::_ForwardFFT<float, float2>( ) {
     cudaErr(cufftExecR2C(cuda_plan_forward, (cufftReal*)position_space_ptr, (cufftComplex*)momentum_space_ptr));
 }
 
+void GpuImage::ForwardFFTBatched(bool should_scale) {
+    MyDebugAssertTrue(dims.y > 1 && dims.x > 1 && dims.z > 1, "ForwardFFTBatched is only implemented for a stack of 2D images");
+    MyDebugAssertTrue(is_in_memory_gpu, "Gpu memory not allocated");
+    MyDebugAssertTrue(is_in_real_space, "Image alread in Fourier space");
+
+    cufft_batch_size = dims.z;
+
+    SetCufftPlan(cistem::fft_type::Enum::inplace_32f_32f_32f_batched, (void*)real_values_gpu, (void*)complex_values_gpu);
+
+    // FIXME, this should be a load call back
+    if ( should_scale ) {
+        this->MultiplyByConstant(ft_normalization_factor * ft_normalization_factor);
+    }
+    _ForwardFFT<float, float2>( );
+    // cudaErr(cufftExecR2C(this->cuda_plan_forward, position_space_ptr, momentum_space_ptr));
+
+    is_in_real_space                 = false;
+    host_image_ptr->is_in_real_space = false;
+    npp_ROI                          = npp_ROI_fourier_space;
+}
+
 void GpuImage::ForwardFFT(bool should_scale) {
 
     bool is_half_precision = false;
@@ -3143,6 +3164,11 @@ void GpuImage::SetCufftPlan(cistem::fft_type::Enum plan_type, void* input_buffer
                 momentum_space_ptr = reinterpret_cast<cufftComplex*>(output_buffer);
                 break;
             }
+            case ft::inplace_32f_32f_32f_batched: {
+                position_space_ptr = reinterpret_cast<cufftReal*>(input_buffer);
+                momentum_space_ptr = reinterpret_cast<cufftComplex*>(output_buffer);
+                break;
+            }
             default: {
                 std::cerr << "Want to set plan type " << cistem::fft_type::names[plan_type] << "\n";
                 MyDebugAssertTrue(false, "Unsupported plan type");
@@ -3152,9 +3178,14 @@ void GpuImage::SetCufftPlan(cistem::fft_type::Enum plan_type, void* input_buffer
     }
 
     int            rank;
-    long long int* fftDims;
-    long long int* inembed;
+    long long int* ifftDims;
+    long long int* offtDims;
+    long long int* inembed; // input storage (not logical) dimensions
     long long int* onembed;
+    long long int  iStride = 1;
+    long long int  oStride = 1;
+    long long int  iDist;
+    long long int  oDist;
 
     cudaErr(cufftCreate(&cuda_plan_forward));
     cudaErr(cufftCreate(&cuda_plan_inverse));
@@ -3162,52 +3193,74 @@ void GpuImage::SetCufftPlan(cistem::fft_type::Enum plan_type, void* input_buffer
     cudaErr(cufftSetStream(cuda_plan_forward, cudaStreamPerThread));
     cudaErr(cufftSetStream(cuda_plan_inverse, cudaStreamPerThread));
 
-    if ( dims.z > 1 ) {
-        rank    = 3;
-        fftDims = new long long int[rank];
-        inembed = new long long int[rank];
-        onembed = new long long int[rank];
+    if ( dims.z > 1 && cufft_batch_size == 1 ) {
+        rank     = 3;
+        ifftDims = new long long int[rank];
+        offtDims = new long long int[rank];
+        inembed  = new long long int[rank];
+        onembed  = new long long int[rank];
 
-        fftDims[0] = dims.z;
-        fftDims[1] = dims.y;
-        fftDims[2] = dims.x;
+        ifftDims[0] = dims.z;
+        ifftDims[1] = dims.y;
+        ifftDims[2] = dims.x;
 
         inembed[0] = dims.z;
         inembed[1] = dims.y;
         inembed[2] = dims.w; // Storage dimension (padded)
 
+        iDist = inembed[0] * inembed[1] * inembed[2];
+
+        offtDims[0] = dims.z;
+        offtDims[1] = dims.y;
+        offtDims[2] = dims.w / 2;
+
         onembed[0] = dims.z;
         onembed[1] = dims.y;
         onembed[2] = dims.w / 2; // Storage dimension (padded)
+
+        oDist = onembed[0] * onembed[1] * onembed[2];
     }
     else if ( dims.y > 1 ) {
-        rank    = 2;
-        fftDims = new long long int[rank];
-        inembed = new long long int[rank];
-        onembed = new long long int[rank];
+        rank     = 2;
+        ifftDims = new long long int[rank];
+        offtDims = new long long int[rank];
+        inembed  = new long long int[rank];
+        onembed  = new long long int[rank];
 
-        fftDims[0] = dims.y;
-        fftDims[1] = dims.x;
+        ifftDims[0] = dims.y;
+        ifftDims[1] = dims.x;
 
         inembed[0] = dims.y;
         inembed[1] = dims.w;
 
+        iDist = inembed[0] * inembed[1];
+
+        offtDims[0] = dims.y;
+        offtDims[1] = dims.w / 2;
+
         onembed[0] = dims.y;
         onembed[1] = dims.w / 2;
+
+        oDist = onembed[0] * onembed[1];
     }
     else {
-        rank    = 1;
-        fftDims = new long long int[rank];
-        inembed = new long long int[rank];
-        onembed = new long long int[rank];
+        rank     = 1;
+        ifftDims = new long long int[rank];
+        offtDims = new long long int[rank];
+        inembed  = new long long int[rank];
+        onembed  = new long long int[rank];
 
-        fftDims[0] = dims.x;
+        ifftDims[0] = dims.x;
+        iDist       = dims.w;
 
         inembed[0] = dims.w;
-        onembed[0] = dims.w / 2;
-    }
 
-    int iBatch = 1;
+        offtDims[0] = dims.w / 2;
+
+        onembed[0] = dims.w / 2;
+
+        oDist = dims.w / 2;
+    }
 
     // As far as I can tell, the padded layout must be assumed and onembed/inembed
     // are not needed. TODO ask John about this.
@@ -3221,31 +3274,34 @@ void GpuImage::SetCufftPlan(cistem::fft_type::Enum plan_type, void* input_buffer
     //                                 NULL, NULL, NULL, CUDA_R_16F, iBatch, &cuda_plan_worksize_inverse, CUDA_R_16F));
     // }
     // else {
-    cudaErr(cufftXtMakePlanMany(cuda_plan_forward, rank, fftDims,
-                                NULL, NULL, NULL,
-                                CUDA_R_32F,
-                                NULL, NULL, NULL,
-                                CUDA_C_32F,
-                                iBatch, &cuda_plan_worksize_forward,
-                                CUDA_C_32F));
 
-    cudaErr(cufftXtMakePlanMany(cuda_plan_inverse, rank, fftDims,
-                                NULL, NULL, NULL,
-                                CUDA_C_32F,
-                                NULL, NULL, NULL,
-                                CUDA_R_32F,
-                                iBatch, &cuda_plan_worksize_inverse,
-                                CUDA_R_32F));
-    // }
+    std::cerr << "FFT plan type " << cistem::fft_type::names[plan_type] << "\n";
+    std::cerr << "inembed " << inembed[0] << " " << inembed[1] << "\n";
+    std::cerr << "onembed " << onembed[0] << " " << onembed[1] << "\n";
+    std::cerr << "iDist " << iDist << "\n";
+    std::cerr << "oDist " << oDist << "\n";
+    std::cerr << "iStride " << iStride << "\n";
+    std::cerr << "oStride " << oStride << "\n";
+    std::cerr << "iBatch " << cufft_batch_size << "\n";
 
-    // //    cufftPlanMany(&dims.cuda_plan_forward, rank, fftDims,
-    // //                  inembed, iStride, iDist,
-    // //                  onembed, oStride, oDist, CUFFT_R2C, iBatch);
-    // //    cufftPlanMany(&dims.cuda_plan_inverse, rank, fftDims,
-    // //                  onembed, oStride, oDist,
-    // //                  inembed, iStride, iDist, CUFFT_C2R, iBatch);
+    cufftErr(cufftXtMakePlanMany(cuda_plan_forward, rank, ifftDims,
+                                 inembed, iStride, iDist,
+                                 CUDA_R_32F,
+                                 onembed, oStride, oDist,
+                                 CUDA_C_32F,
+                                 cufft_batch_size, &cuda_plan_worksize_forward,
+                                 CUDA_C_32F));
 
-    delete[] fftDims;
+    cufftErr(cufftXtMakePlanMany(cuda_plan_inverse, rank, offtDims,
+                                 onembed, oStride, oDist,
+                                 CUDA_C_32F,
+                                 inembed, iStride, iDist,
+                                 CUDA_C_32F,
+                                 cufft_batch_size, &cuda_plan_worksize_inverse,
+                                 CUDA_R_32F));
+
+    delete[] ifftDims;
+    delete[] offtDims;
     delete[] inembed;
     delete[] onembed;
 }
@@ -3285,6 +3341,7 @@ void GpuImage::Deallocate( ) {
         cudaErr(cufftDestroy(cuda_plan_inverse));
         cudaErr(cufftDestroy(cuda_plan_forward));
         set_plan_type             = cistem::fft_type::Enum::unset;
+        cufft_batch_size          = 1;
         is_set_complexConjMulLoad = false;
     }
 
@@ -3451,7 +3508,8 @@ void GpuImage::UpdateBoolsToDefault( ) {
     is_host_memory_pinned = false;
 
     // libraries
-    set_plan_type = cistem::fft_type::Enum::unset;
+    set_plan_type    = cistem::fft_type::Enum::unset;
+    cufft_batch_size = 1;
     //	is_cublas_loaded = false;
     is_npp_loaded = false;
 
@@ -3887,6 +3945,7 @@ void GpuImage::Consume(GpuImage* other_image) {
     cuda_plan_forward = other_image->cuda_plan_forward;
     cuda_plan_inverse = other_image->cuda_plan_inverse;
     set_plan_type     = other_image->set_plan_type;
+    cufft_batch_size  = other_image->cufft_batch_size;
 
     // We neeed to override the other image pointers so that it doesn't deallocate the memory.
     other_image->real_values_gpu    = NULL;

--- a/src/gpu/GpuImage.h
+++ b/src/gpu/GpuImage.h
@@ -66,25 +66,27 @@ class GpuImage {
     cufftReal*    real_values_gpu; // !<  Real array to hold values for REAL images.
     cufftComplex* complex_values_gpu; // !<  Complex array to hold values for COMP images.
 
-    __half*  real_values_16f;
-    __half2* complex_values_16f;
-    __half*  ctf_buffer_16f;
-    __half2* ctf_complex_buffer_16f;
+    // The half precision buffers may be used as fp16 or bfloat16 and it is up to the user to track what is what.
+    // This of course assumes they have the same size, which they should.
+    static constexpr size_t size_of_half = sizeof(__half);
+    static_assert(size_of_half == sizeof(nv_bfloat16), "it is assumed sizeof(fp16) == sizeof(bfloat16)");
+    static_assert(size_of_half * 2 == sizeof(nv_bfloat162), "it is assumed sizeof(fp16) == sizeof(bfloat16)");
+    static_assert(size_of_half == sizeof(half_float::half), "GPU and CPU half precision types must be the same size");
 
-    // inline float ReturnAsFloat(float* h) {
-    //     *tmpVal = h;
-    //     return *tmpVal;
-    // };
+    void* real_values_16f;
+    void* complex_values_16f;
+    void* ctf_buffer_16f;
+    void* ctf_complex_buffer_16f;
 
-    // inline float ReturnAsFloat(__half* h) {
-    //     *tmpVal = __half2float(h);
-    //     return *tmpVal;
-    // };
+    __half*  real_values_fp16        = reinterpret_cast<__half*>(real_values_16f);
+    __half2* complex_values_fp16     = reinterpret_cast<__half2*>(complex_values_16f);
+    __half*  ctf_buffer_fp16         = reinterpret_cast<__half*>(ctf_buffer_16f);
+    __half2* ctf_complex_buffer_fp16 = reinterpret_cast<__half2*>(ctf_complex_buffer_16f);
 
-    // inline float ReturnAsFloat(nv_bfloat16* h) {
-    //     *tmpVal = __bfloat162float(h);
-    //     return *tmpVal;
-    // };
+    nv_bfloat16*  real_values_bf16        = reinterpret_cast<nv_bfloat16*>(real_values_16f);
+    nv_bfloat162* complex_values_bf16     = reinterpret_cast<nv_bfloat162*>(complex_values_16f);
+    nv_bfloat16*  ctf_buffer_bf16         = reinterpret_cast<nv_bfloat16*>(ctf_buffer_16f);
+    nv_bfloat162* ctf_complex_buffer_bf16 = reinterpret_cast<nv_bfloat162*>(ctf_complex_buffer_16f);
 
     // We want to be able to re-use the texture object, so only set it up once.
     cudaTextureObject_t tex_real;

--- a/src/gpu/GpuImage.h
+++ b/src/gpu/GpuImage.h
@@ -63,8 +63,12 @@ class GpuImage {
     // end  MEMBER VARIABLES FROM THE cpu IMAGE CLASS
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    cufftReal*    real_values_gpu; // !<  Real array to hold values for REAL images.
-    cufftComplex* complex_values_gpu; // !<  Complex array to hold values for COMP images.
+    float*  real_values_gpu; // !<  Real array to hold values for REAL images.
+    float2* complex_values_gpu; // !<  Complex array to hold values for COMP images.
+
+    // To make it easier to switch between different types of FFT plans we have void pointers for them here
+    void* position_space_ptr;
+    void* momentum_space_ptr;
 
     // The half precision buffers may be used as fp16 or bfloat16 and it is up to the user to track what is what.
     // This of course assumes they have the same size, which they should.
@@ -149,7 +153,6 @@ class GpuImage {
 
     void PrintNppStreamContext( );
 
-    bool is_fft_planned;
     //	bool is_cublas_loaded;
     bool is_npp_loaded;
     //	cublasStatus_t cublas_stat;
@@ -188,6 +191,13 @@ class GpuImage {
     void ClipIntoFourierSpace(GpuImage* destination_image, float wanted_padding_value);
 
     void ClipIntoReturnMask(GpuImage* other_image);
+
+    // Used with explicit specializtion
+    template <class InputType, class OutputType>
+    void _ForwardFFT( );
+
+    template <class InputType, class OutputType>
+    void _BackwardFFT( );
 
     void ForwardFFT(bool should_scale = true); /**CPU_eq**/
     void BackwardFFT( ); /**CPU_eq**/
@@ -257,10 +267,11 @@ class GpuImage {
     Peak FindPeakWithParabolaFit(float inner_radius_for_peak_search, float outer_radius_for_peak_search);
     Peak FindPeakAtOriginFast2D(int wanted_max_pix_x, int wanted_max_pix_y, bool load_half_precision = false);
 
-    bool Init(Image& cpu_image, bool pin_host_memory = true, bool allocate_real_values = true);
-    void SetCufftPlan(bool use_half_precision = false);
-    void SetupInitialValues( );
-    void UpdateBoolsToDefault( );
+    bool                   Init(Image& cpu_image, bool pin_host_memory = true, bool allocate_real_values = true);
+    void                   SetCufftPlan(cistem::fft_type::Enum plan_type, void* input_buffer, void* output_buffer);
+    cistem::fft_type::Enum set_plan_type;
+    void                   SetupInitialValues( );
+    void                   UpdateBoolsToDefault( );
 
     template <int ntds_x = 32, int ntds_y = 32>
     __inline__ void ReturnLaunchParameters(int4 input_dims, bool real_space) {

--- a/src/gpu/GpuImage.h
+++ b/src/gpu/GpuImage.h
@@ -146,6 +146,8 @@ class GpuImage {
     size_t      cuda_plan_worksize_forward;
     size_t      cuda_plan_worksize_inverse;
 
+    int cufft_batch_size;
+
     //Stream for asynchronous command execution
     cudaStream_t     calcStream;
     cudaStream_t     copyStream;
@@ -200,7 +202,11 @@ class GpuImage {
     void _BackwardFFT( );
 
     void ForwardFFT(bool should_scale = true); /**CPU_eq**/
+    void ForwardFFTBatched(bool should_scale = true);
+
     void BackwardFFT( ); /**CPU_eq**/
+    void BackwardFFTBatched( );
+
     void ForwardFFTAndClipInto(GpuImage& image_to_insert, bool should_scale);
     template <typename T>
     void BackwardFFTAfterComplexConjMul(T* image_to_multiply, bool load_half_precision);

--- a/src/gpu/TemplateMatchingCore.cu
+++ b/src/gpu/TemplateMatchingCore.cu
@@ -203,7 +203,7 @@ void TemplateMatchingCore::RunInnerLoop(Image& projection_filter, float c_pixel,
             d_padded_reference.ForwardFFT(false);
 
             //      d_padded_reference.ForwardFFTAndClipInto(d_current_projection,false);
-            d_padded_reference.BackwardFFTAfterComplexConjMul(d_input_image.complex_values_16f, true);
+            d_padded_reference.BackwardFFTAfterComplexConjMul(d_input_image.complex_values_fp16, true);
 
             //			d_padded_reference.BackwardFFTAfterComplexConjMul(d_input_image.complex_values_gpu, false);
             //			d_padded_reference.ConvertToHalfPrecision(false);

--- a/src/gpu/gpu_core_headers.h
+++ b/src/gpu/gpu_core_headers.h
@@ -26,12 +26,14 @@ const int MAX_GPU_COUNT = 32;
 #define cudaErr(err, ...) { err; }
 #define nppErr(err, ...) { err; }
 #define cuTensorErr(err, ...) { err; }
+#define cufftErr(err, ...) { err; }
 #define postcheck 
 #define precheck 
 #else
 // The static path to the error code definitions is brittle, but better than the internet. At least you can click in VSCODE to get there.
 #define nppErr(npp_stat)  {if (npp_stat != NPP_SUCCESS) { std::cerr << "NPP_CHECK_NPP - npp_stat = " << npp_stat ; wxPrintf(" at %s:(%d)\nFind error codes at /usr/local/cuda-11.7/targets/x86_64-linux/include/nppdefs.h:(170)\n\n",__FILE__,__LINE__); DEBUG_ABORT} }
 #define cudaErr(error) { auto status = static_cast<cudaError_t>(error); if (status != cudaSuccess) { std::cerr << cudaGetErrorString(status) << " :-> "; MyPrintWithDetails(""); DEBUG_ABORT} }
+#define cufftErr(error) { auto status = static_cast<cufftResult>(error); if (status != CUFFT_SUCCESS) { std::cerr << cistem::gpu::cufft_error_types[status] << " :-> "; MyPrintWithDetails(""); DEBUG_ABORT} }
 #define cuTensorErr(error) { auto status = static_cast<cutensorStatus_t>(error); if (status != CUTENSOR_STATUS_SUCCESS) { std::cerr << cutensorGetErrorString(status) << " :-> "; MyPrintWithDetails(""); DEBUG_ABORT} }
 #define postcheck { cudaErr(cudaPeekAtLastError()); cudaError_t error = cudaStreamSynchronize(cudaStreamPerThread); cudaErr(error); }
 #define precheck { cudaErr(cudaGetLastError()) }

--- a/src/gpu/gpu_image_cuFFT_callbacks.h
+++ b/src/gpu/gpu_image_cuFFT_callbacks.h
@@ -1,0 +1,92 @@
+
+
+// cuFFT callbacks
+// These must be linked with the static cuFFT library.
+// As of cuda 11.4 callbacks are deprecated for separate compilation. These will eventually be replaced with FastFFT.
+
+__device__ cufftReal CB_ConvertInputf16Tof32(void* dataIn, size_t offset, void* callerInfo, void* sharedPtr);
+
+__device__ cufftReal CB_ConvertInputf16Tof32(void* dataIn, size_t offset, void* callerInfo, void* sharedPtr) {
+
+    const __half element = ((__half*)dataIn)[offset];
+    return (cufftReal)(__half2float(element));
+}
+
+__device__ cufftCallbackLoadR d_ConvertInputf16Tof32Ptr = CB_ConvertInputf16Tof32;
+
+__device__ void CB_scaleFFTAndStore(void* dataOut, size_t offset, cufftComplex element, void* callerInfo, void* sharedPtr);
+
+__device__ void CB_scaleFFTAndStore(void* dataOut, size_t offset, cufftComplex element, void* callerInfo, void* sharedPtr) {
+    float scale_factor = *(float*)callerInfo;
+
+    ((cufftComplex*)dataOut)[offset] = (cufftComplex)ComplexScale(element, scale_factor);
+}
+
+//__device__ cufftCallbackLoadR d_ConvertInputf16Tof32Ptr = CB_ConvertInputf16Tof32;
+__device__ cufftCallbackStoreC d_scaleFFTAndStorePtr = CB_scaleFFTAndStore;
+
+__device__ void CB_mipCCGAndStore(void* dataOut, size_t offset, cufftReal element, void* callerInfo, void* sharedPtr);
+
+__device__ void CB_mipCCGAndStore(void* dataOut, size_t offset, cufftReal element, void* callerInfo, void* sharedPtr) {
+
+    __half* data_out_half = (__half*)callerInfo;
+    //	data_out_half[offset] = __float2half(element);
+    //	((cufftReal *)dataOut)[offset] = element;
+
+#ifdef DISABLECACHEHINTS
+    ((__half*)data_out_half)[offset] = __float2half(element);
+#else
+    __stcs(&data_out_half[offset], __float2half(element));
+#endif
+
+    //	)_(dataOut)[offset] = __float2half(element);
+    //
+}
+
+__device__ cufftCallbackStoreR d_mipCCGAndStorePtr = CB_mipCCGAndStore;
+
+template <typename T>
+struct CB_complexConjMulLoad_params {
+    T*    target;
+    float scale;
+};
+
+static __device__ cufftComplex CB_complexConjMulLoad_32f(void* dataIn, size_t offset, void* callerInfo, void* sharedPtr);
+static __device__ cufftComplex CB_complexConjMulLoad_16f(void* dataIn, size_t offset, void* callerInfo, void* sharedPtr);
+
+static __device__ cufftComplex CB_complexConjMulLoad_32f(void* dataIn, size_t offset, void* callerInfo, void* sharedPtr) {
+    CB_complexConjMulLoad_params<cufftComplex>* my_params = (CB_complexConjMulLoad_params<cufftComplex>*)callerInfo;
+    return (cufftComplex)ComplexConjMulAndScale(my_params->target[offset], ((Complex*)dataIn)[offset], my_params->scale);
+    //    return (cufftComplex)make_float2(my_params->scale * __fmaf_rn(my_params->target[offset].x ,  ((Complex *)dataIn)[offset].x, my_params->target[offset].y * ((Complex *)dataIn)[offset].y),
+    //    		my_params->scale * __fmaf_rn(my_params->target[offset].y , -((Complex *)dataIn)[offset].x, my_params->target[offset].x * ((Complex *)dataIn)[offset].y));
+}
+
+static __device__ cufftComplex CB_complexConjMulLoad_16f(void* dataIn, size_t offset, void* callerInfo, void* sharedPtr) {
+    CB_complexConjMulLoad_params<__half2>* my_params = (CB_complexConjMulLoad_params<__half2>*)callerInfo;
+    return (cufftComplex)ComplexConjMulAndScale((cufftComplex)__half22float2(my_params->target[offset]), ((Complex*)dataIn)[offset], my_params->scale);
+}
+
+__device__ cufftCallbackLoadC d_complexConjMulLoad_32f = CB_complexConjMulLoad_32f;
+__device__ cufftCallbackLoadC d_complexConjMulLoad_16f = CB_complexConjMulLoad_16f;
+
+typedef struct _CB_realLoadAndClipInto_params {
+    int*       mask;
+    cufftReal* target;
+
+} CB_realLoadAndClipInto_params;
+
+static __device__ cufftReal CB_realLoadAndClipInto(void* dataIn, size_t offset, void* callerInfo, void* sharedPtr);
+
+static __device__ cufftReal CB_realLoadAndClipInto(void* dataIn, size_t offset, void* callerInfo, void* sharedPtr) {
+
+    CB_realLoadAndClipInto_params* my_params = (CB_realLoadAndClipInto_params*)callerInfo;
+    int                            idx       = my_params->mask[offset];
+    if ( idx == 0 ) {
+        return 0.0f;
+    }
+    else {
+        return my_params->target[idx];
+    }
+}
+
+__device__ cufftCallbackLoadR d_realLoadAndClipInto = CB_realLoadAndClipInto;

--- a/src/programs/samples/1_cpu_gpu_comparison/resize_comparison.cpp
+++ b/src/programs/samples/1_cpu_gpu_comparison/resize_comparison.cpp
@@ -44,7 +44,7 @@ bool DoCPUvsGPURealSpaceResize(wxString hiv_image_80x80x1_filename, wxString tem
     wxString tmp_img_filename = temp_directory + "/tmp1.mrc";
 
     MRCFile input_file(hiv_image_80x80x1_filename.ToStdString( ), false);
-    MRCFile output_file(tmp_img_filename.ToStdString( ), false);
+    MRCFile output_file(tmp_img_filename.ToStdString( ), true);
 
     all_passed = all_passed && passed;
 
@@ -126,7 +126,7 @@ bool DoCPUvsGPUFourierResize(wxString hiv_image_80x80x1_filename, wxString temp_
 
     wxString tmp_img_filename = temp_directory + "/tmp1.mrc";
 
-    MRCFile output_file(tmp_img_filename.ToStdString( ), false);
+    MRCFile output_file(tmp_img_filename.ToStdString( ), true);
 
     SamplesBeginTest("Fourier Crop CPU and GPU images", passed);
     Image cpu_image;

--- a/src/programs/samples/1_cpu_gpu_comparison/statistical_ops.cpp
+++ b/src/programs/samples/1_cpu_gpu_comparison/statistical_ops.cpp
@@ -21,7 +21,7 @@ bool CPUvsGPUStatisticalOpsTest(const wxString& hiv_image_80x80x1_filename, wxSt
 
     SamplesPrintTestStartMessage("Starting CPU vs GPU masking tests:", false);
 
-    all_passed = all_passed && DoStatsticalMomentsTests(hiv_image_80x80x1_filename, temp_directory);
+    // all_passed = all_passed && DoStatsticalMomentsTests(hiv_image_80x80x1_filename, temp_directory);
     // all_passed = all_passed && DoExtremumTests(hiv_image_80x80x1_filename, temp_directory);
 
     SamplesBeginTest("CPU vs GPU overall", passed);

--- a/src/programs/samples/4_ffts/simple_cufft.cpp
+++ b/src/programs/samples/4_ffts/simple_cufft.cpp
@@ -1,0 +1,116 @@
+#include <cistem_config.h>
+
+#ifdef ENABLEGPU
+#include "../../../gpu/gpu_core_headers.h"
+#else
+#error "GPU is not enabled"
+#include "../../../core/core_headers.h"
+#endif
+
+#include "../../../gpu/GpuImage.h"
+
+#include "../common/common.h"
+#include "simple_cufft.h"
+
+bool GpuFftOps(const wxString& hiv_image_80x80x1_filename, wxString& temp_directory) {
+
+    bool passed;
+    bool all_passed = true;
+
+    SamplesPrintTestStartMessage("Starting GPU FFT tests:", false);
+
+    all_passed = all_passed && DoInPlaceR2CandC2R(hiv_image_80x80x1_filename, temp_directory);
+
+    SamplesBeginTest("GPU FFT tests overall", passed);
+    SamplesPrintResult(all_passed, __LINE__);
+    wxPrintf("\n\n");
+
+    return all_passed;
+}
+
+bool DoInPlaceR2CandC2R(const wxString& hiv_image_80x80x1_filename, wxString& temp_directory) {
+
+    bool passed     = true;
+    bool all_passed = true;
+
+    SamplesBeginTest("Square 2D R2C/C2R inplace ffts", passed);
+
+    // Compare the default ops to the cpu (FFTW/MKL version)
+    // These are single precision, inplace ffts, with FFTW layout.
+
+    Image test_image;
+
+    std::vector<size_t> fft_sizes   = {64, 256, 384, 512, 648, 1024, 3456, 4096};
+    constexpr size_t    max_3d_size = 648;
+
+    constexpr bool should_allocate_in_real_space = true;
+    constexpr bool should_make_fftw_plan         = true;
+    // First we will test square images.
+    // TODO: add fuzzing over noise distributions, maybe that fits better somewhere else? Or better yet, this method
+    // could be called for various noise distributions.
+    for ( auto iSize : fft_sizes ) {
+
+        test_image.Allocate(iSize, iSize, 1, should_allocate_in_real_space, should_make_fftw_plan);
+        test_image.FillWithNoiseFromNormalDistribution(0.f, 1.f);
+        GpuImage gpu_test_image;
+        gpu_test_image.Init(test_image);
+        gpu_test_image.CopyHostToDeviceAndSynchronize( );
+
+        test_image.ForwardFFT( );
+        gpu_test_image.ForwardFFT( );
+
+        // This call also frees the GPU memory and unpins the hsot memory
+        Image gpu_cpu_buffer = gpu_test_image.CopyDeviceToNewHost(true, true, true);
+
+        CompareComplexValues(test_image, gpu_cpu_buffer);
+    }
+
+    all_passed = all_passed && passed;
+    SamplesTestResult(passed);
+
+    SamplesBeginTest("Cubic  3D R2C/C2R inplace ffts", passed);
+    for ( auto iSize : fft_sizes ) {
+        if ( iSize > max_3d_size ) {
+            continue;
+        }
+        test_image.Allocate(iSize, iSize, 1, should_allocate_in_real_space, should_make_fftw_plan);
+        test_image.FillWithNoiseFromNormalDistribution(0.f, 1.f);
+        GpuImage gpu_test_image;
+        gpu_test_image.Init(test_image);
+        gpu_test_image.CopyHostToDeviceAndSynchronize( );
+
+        test_image.ForwardFFT( );
+        gpu_test_image.ForwardFFT( );
+
+        // This call also frees the GPU memory and unpins the hsot memory
+        Image gpu_cpu_buffer = gpu_test_image.CopyDeviceToNewHost(true, true, true);
+
+        CompareComplexValues(test_image, gpu_cpu_buffer);
+    }
+
+    all_passed = all_passed && passed;
+    SamplesTestResult(passed);
+
+    SamplesBeginTest("Non-Sq 2D R2C/C2R inplace ffts", passed);
+    for ( int i = 1; i < fft_sizes.size( ); i++ ) {
+
+        test_image.Allocate(fft_sizes[i], fft_sizes[i - 1], 1, should_allocate_in_real_space, should_make_fftw_plan);
+        test_image.FillWithNoiseFromNormalDistribution(0.f, 1.f);
+        GpuImage gpu_test_image;
+        gpu_test_image.Init(test_image);
+        gpu_test_image.CopyHostToDeviceAndSynchronize( );
+
+        test_image.ForwardFFT( );
+        gpu_test_image.ForwardFFT( );
+
+        // This call also frees the GPU memory and unpins the hsot memory
+        Image gpu_cpu_buffer = gpu_test_image.CopyDeviceToNewHost(true, true, true);
+
+        CompareComplexValues(test_image, gpu_cpu_buffer);
+    }
+
+    all_passed = all_passed && passed;
+    SamplesTestResult(passed);
+
+    return all_passed;
+}

--- a/src/programs/samples/4_ffts/simple_cufft.cpp
+++ b/src/programs/samples/4_ffts/simple_cufft.cpp
@@ -12,6 +12,13 @@
 #include "../common/common.h"
 #include "simple_cufft.h"
 
+#define RUN_TIMING_TESTS
+#ifdef RUN_TIMING_TESTS
+using namespace cistem_timer;
+#else
+using namespace cistem_timer_noop;
+#endif
+
 bool GpuFftOps(const wxString& hiv_image_80x80x1_filename, wxString& temp_directory) {
 
     bool passed;
@@ -20,6 +27,7 @@ bool GpuFftOps(const wxString& hiv_image_80x80x1_filename, wxString& temp_direct
     SamplesPrintTestStartMessage("Starting GPU FFT tests:", false);
 
     all_passed = all_passed && DoInPlaceR2CandC2R(hiv_image_80x80x1_filename, temp_directory);
+    all_passed = all_passed && DoInPlaceR2CandC2RBatched(hiv_image_80x80x1_filename, temp_directory);
 
     SamplesBeginTest("GPU FFT tests overall", passed);
     SamplesPrintResult(all_passed, __LINE__);
@@ -132,6 +140,108 @@ bool DoInPlaceR2CandC2R(const wxString& hiv_image_80x80x1_filename, wxString& te
 
     all_passed = all_passed && passed;
     SamplesTestResult(passed);
+
+    return all_passed;
+}
+
+bool DoInPlaceR2CandC2RBatched(const wxString& hiv_image_80x80x1_filename, wxString& temp_directory) {
+
+    bool passed     = true;
+    bool all_passed = true;
+
+    SamplesBeginTest("Batched 2d ffts (accuracy)", passed);
+
+    constexpr size_t image_size = 256;
+    constexpr size_t batch_size = 400;
+
+
+    std::array<Image, batch_size>    cpu_individual;
+    std::array<GpuImage, batch_size> gpu_individual;
+
+    // Create two 3d images to mirror the stack of 2ds, but with contiguous image datas memory.
+    Image    cpu_batch;
+    GpuImage gpu_batch;
+
+    constexpr bool should_allocate_in_real_space = true;
+    constexpr bool should_make_fftw_plan         = true;
+
+    // Allocate and fill the 3d with random data, and then we will point each of the individual 2ds at the
+    // correct place in the 3d's image memory.
+
+    cpu_batch.Allocate(image_size, image_size, batch_size, should_allocate_in_real_space, should_make_fftw_plan);
+    cpu_batch.FillWithNoiseFromNormalDistribution(0.f, 1.f);
+
+    gpu_batch.Init(cpu_batch, true, true);
+    gpu_batch.CopyHostToDeviceAndSynchronize( );
+
+    int stride = (cpu_batch.padding_jump_value + cpu_batch.logical_x_dimension) * cpu_batch.logical_y_dimension;
+    for ( int i = 0; i < batch_size; i++ ) {
+        cpu_individual[i].Allocate(image_size, image_size, 1, should_allocate_in_real_space, should_make_fftw_plan);
+        cpu_individual[i].real_values    = &cpu_batch.real_values[i * stride];
+        cpu_individual[i].complex_values = (std::complex<float>*)cpu_individual[i].real_values;
+
+        // The cpu memory is already pinned
+        gpu_individual[i].Init(cpu_individual[i], false, true);
+        gpu_individual[i].CopyHostToDeviceAndSynchronize( );
+    }
+
+    StopWatch timer;
+
+    timer.start("GPU 2d");
+    for ( int i = 0; i < batch_size; i++ ) {
+        gpu_individual[i].ForwardFFT( );
+    }
+    timer.lap_sync("GPU 2d");
+
+    timer.start("Gpu 2d batched");
+    gpu_batch.ForwardFFTBatched( );
+    timer.lap_sync("Gpu 2d batched");
+
+    cudaErr(cudaStreamSynchronize(cudaStreamPerThread));
+
+    // Create some clean images for our equality test.
+    Image    tmp_ind, tmp_batch;
+    GpuImage tmp_gpu_batch;
+
+    // Again, this memory is already pinned on the host, so don't attempt to re-pin it here.
+    tmp_gpu_batch.Init(cpu_individual[0], false, true);
+    for ( int i = 0; i < batch_size; i++ ) {
+        // if we add the BackwardFFT to the test, we may not want to clear the memory here
+        tmp_ind                       = gpu_individual[i].CopyDeviceToNewHost(true, true, true);
+        tmp_gpu_batch.real_values_gpu = &gpu_batch.real_values_gpu[stride * i];
+        tmp_batch                     = tmp_gpu_batch.CopyDeviceToNewHost(true, false, false);
+
+        passed = passed && CompareComplexValues(tmp_ind, tmp_batch);
+    }
+
+    // We can't safely leave these pointers at memory the don't own.
+    // I guess this also means the memory allocated originally is not cleared? I suppose some type of "borrowmemory"
+    // Function that upone destruction "returns" the memory (just doesn't free it) and then *does* free it's own memory
+    // would be useful.
+    tmp_gpu_batch.real_values_gpu = nullptr;
+    for ( int i = 0; i < batch_size; i++ ) {
+        cpu_individual[i].real_values = nullptr;
+    }
+
+    float ratio_seq_to_batched = timer.get_ratio_of_times("GPU 2d", "Gpu 2d batched");
+    // wxPrintf("Ratio of tims is %f\n", ratio_seq_to_batched);
+    // timer.print_times( );
+
+    all_passed = all_passed && passed;
+    SamplesTestResult(passed);
+
+    SamplesBeginTest("Batched 2d ffts (performance)", passed);
+
+    // For size 256 on Salina (rtx 3080 ti and AMD 5950 this is usually 65-70 )
+    passed = passed && ratio_seq_to_batched > 50.f;
+
+    all_passed = all_passed && passed;
+    SamplesTestResult(passed);
+    // for ( int i = 0; i < batch_size; i++ ) {
+    //     gpu_individual[i].Deallocate( );
+    // }
+    // delete[] cpu_individual;
+    // delete[] gpu_individual;
 
     return all_passed;
 }

--- a/src/programs/samples/4_ffts/simple_cufft.cpp
+++ b/src/programs/samples/4_ffts/simple_cufft.cpp
@@ -59,10 +59,17 @@ bool DoInPlaceR2CandC2R(const wxString& hiv_image_80x80x1_filename, wxString& te
         test_image.ForwardFFT( );
         gpu_test_image.ForwardFFT( );
 
-        // This call also frees the GPU memory and unpins the hsot memory
-        Image gpu_cpu_buffer = gpu_test_image.CopyDeviceToNewHost(true, true, true);
+        Image gpu_cpu_buffer = gpu_test_image.CopyDeviceToNewHost(true, false, false);
 
-        CompareComplexValues(test_image, gpu_cpu_buffer);
+        passed = passed && CompareComplexValues(test_image, gpu_cpu_buffer);
+
+        test_image.BackwardFFT( );
+        gpu_test_image.BackwardFFT( );
+
+        // This call also frees the GPU memory and unpins the hsot memory
+        gpu_cpu_buffer = gpu_test_image.CopyDeviceToNewHost(true, true, true);
+
+        passed = passed && CompareRealValues(test_image, gpu_cpu_buffer);
     }
 
     all_passed = all_passed && passed;
@@ -82,10 +89,17 @@ bool DoInPlaceR2CandC2R(const wxString& hiv_image_80x80x1_filename, wxString& te
         test_image.ForwardFFT( );
         gpu_test_image.ForwardFFT( );
 
-        // This call also frees the GPU memory and unpins the hsot memory
-        Image gpu_cpu_buffer = gpu_test_image.CopyDeviceToNewHost(true, true, true);
+        Image gpu_cpu_buffer = gpu_test_image.CopyDeviceToNewHost(true, false, false);
 
-        CompareComplexValues(test_image, gpu_cpu_buffer);
+        passed = passed && CompareComplexValues(test_image, gpu_cpu_buffer);
+
+        test_image.BackwardFFT( );
+        gpu_test_image.BackwardFFT( );
+
+        // This call also frees the GPU memory and unpins the hsot memory
+        gpu_cpu_buffer = gpu_test_image.CopyDeviceToNewHost(true, true, true);
+
+        passed = passed && CompareRealValues(test_image, gpu_cpu_buffer);
     }
 
     all_passed = all_passed && passed;
@@ -103,10 +117,17 @@ bool DoInPlaceR2CandC2R(const wxString& hiv_image_80x80x1_filename, wxString& te
         test_image.ForwardFFT( );
         gpu_test_image.ForwardFFT( );
 
-        // This call also frees the GPU memory and unpins the hsot memory
-        Image gpu_cpu_buffer = gpu_test_image.CopyDeviceToNewHost(true, true, true);
+        Image gpu_cpu_buffer = gpu_test_image.CopyDeviceToNewHost(true, false, false);
 
-        CompareComplexValues(test_image, gpu_cpu_buffer);
+        passed = passed && CompareComplexValues(test_image, gpu_cpu_buffer);
+
+        test_image.BackwardFFT( );
+        gpu_test_image.BackwardFFT( );
+
+        // This call also frees the GPU memory and unpins the hsot memory
+        gpu_cpu_buffer = gpu_test_image.CopyDeviceToNewHost(true, true, true);
+
+        passed = passed && CompareRealValues(test_image, gpu_cpu_buffer);
     }
 
     all_passed = all_passed && passed;

--- a/src/programs/samples/4_ffts/simple_cufft.h
+++ b/src/programs/samples/4_ffts/simple_cufft.h
@@ -1,0 +1,7 @@
+#ifndef SRC_PROGRAMS_SAMPLES_4_FFTS_SIMPLE_CUFFT_H_
+#define SRC_PROGRAMS_SAMPLES_4_FFTS_SIMPLE_CUFFT_H_
+
+bool GpuFftOps(const wxString& hiv_image_80x80x1_filename, wxString& temp_directory);
+bool DoInPlaceR2CandC2R(const wxString& hiv_image_80x80x1_filename, wxString& temp_directory);
+
+#endif

--- a/src/programs/samples/4_ffts/simple_cufft.h
+++ b/src/programs/samples/4_ffts/simple_cufft.h
@@ -3,5 +3,6 @@
 
 bool GpuFftOps(const wxString& hiv_image_80x80x1_filename, wxString& temp_directory);
 bool DoInPlaceR2CandC2R(const wxString& hiv_image_80x80x1_filename, wxString& temp_directory);
+bool DoInPlaceR2CandC2RBatched(const wxString& hiv_image_80x80x1_filename, wxString& temp_directory);
 
 #endif

--- a/src/programs/samples/common/helper_functions.cpp
+++ b/src/programs/samples/common/helper_functions.cpp
@@ -77,6 +77,32 @@ bool CompareRealValues(Image& first_image, Image& second_image, float minimum_cc
     }
 }
 
+bool CompareComplexValues(Image& first_image, Image& second_image, float minimum_ccc, float mask_radius) {
+
+    MyDebugAssertTrue(first_image.is_in_memory, "First image is not in memory");
+    MyDebugAssertTrue(second_image.is_in_memory, "Second image is not in memory");
+    MyDebugAssertFalse(first_image.is_in_real_space, "First image is not in real space");
+    MyDebugAssertFalse(second_image.is_in_real_space, "Second image is not in real space");
+    MyDebugAssertTrue(first_image.HasSameDimensionsAs(&second_image), "Images must have same dimensions");
+
+    // use everything within nyquist (maybe the corners should be checked too?)
+    constexpr float low_limit2       = 0.f;
+    constexpr float high_limit2      = 0.25f;
+    constexpr float signed_cc_limit2 = 0.25f;
+
+    float score = first_image.GetWeightedCorrelationWithImage(second_image, low_limit2, high_limit2, signed_cc_limit2);
+
+    if ( score < minimum_ccc ) {
+        wxPrintf("\nFailed CCC is %g\n", score);
+        first_image.QuickAndDirtyWriteSlice("first_image.mrc", 1);
+        second_image.QuickAndDirtyWriteSlice("second_image.mrc", 1);
+        return false;
+    }
+    else {
+        return true;
+    }
+}
+
 // void SamplesPrintResult(wxString testName, bool result) {
 
 //   wxPrintf("\t%s",testName);

--- a/src/programs/samples/common/helper_functions.h
+++ b/src/programs/samples/common/helper_functions.h
@@ -10,7 +10,9 @@ void print2DArray(Image& image);
 
 void PrintArray(float* p, int maxLoops = 10);
 
-bool  CompareRealValues(Image& first_image, Image& second_image, float minimum_ccc = 0.999f, float mask_radius = 0.f);
+bool CompareRealValues(Image& first_image, Image& second_image, float minimum_ccc = 0.999f, float mask_radius = 0.f);
+bool CompareComplexValues(Image& first_image, Image& second_image, float minimum_ccc = 0.999f, float mask_radius = 0.f);
+
 Image GetAbsOfFourierTransformAsRealImage(Image& input_image);
 
 void SamplesPrintTestStartMessage(wxString message, bool bold = false);

--- a/src/programs/samples/samples_functional_testing.cpp
+++ b/src/programs/samples/samples_functional_testing.cpp
@@ -19,6 +19,7 @@
 #include "1_cpu_gpu_comparison/masking.h"
 #include "1_cpu_gpu_comparison/statistical_ops.h"
 #include "3_tensor_ops/gpu_image_tensor_ops.h"
+#include "4_ffts/simple_cufft.h"
 
 // Test data
 #include "../console_test/hiv_image_80x80x1.cpp"
@@ -42,7 +43,8 @@ bool SamplesTestingApp::DoCalculation( ) {
 #ifdef ENABLEGPU
     // These are broken, I'm not quite sure where, seems to be allocation issues related to consme that Shiran wrote. Revisit.
     // FIXME, turn back on the tests when done debugging
-    all_tests_passed = all_tests_passed && DoBasicTensorOpsTest(hiv_images_80x80x10_filename, temp_directory);
+    all_tests_passed = all_tests_passed && GpuFftOps(hiv_image_80x80x1_filename, temp_directory);
+    // all_tests_passed = all_tests_passed && DoBasicTensorOpsTest(hiv_images_80x80x10_filename, temp_directory);
     // all_tests_passed = all_tests_passed && CPUvsGPUMaskingTest(hiv_image_80x80x1_filename, temp_directory);
     // all_tests_passed = all_tests_passed && DoCPUvsGPUResize(hiv_image_80x80x1_filename, temp_directory);
     // all_tests_passed = all_tests_passed && CPUvsGPUProjectionTest(temp_directory);

--- a/src/programs/samples/samples_functional_testing.cpp
+++ b/src/programs/samples/samples_functional_testing.cpp
@@ -45,10 +45,10 @@ bool SamplesTestingApp::DoCalculation( ) {
     // FIXME, turn back on the tests when done debugging
     all_tests_passed = all_tests_passed && GpuFftOps(hiv_image_80x80x1_filename, temp_directory);
     // all_tests_passed = all_tests_passed && DoBasicTensorOpsTest(hiv_images_80x80x10_filename, temp_directory);
-    // all_tests_passed = all_tests_passed && CPUvsGPUMaskingTest(hiv_image_80x80x1_filename, temp_directory);
-    // all_tests_passed = all_tests_passed && DoCPUvsGPUResize(hiv_image_80x80x1_filename, temp_directory);
-    // all_tests_passed = all_tests_passed && CPUvsGPUProjectionTest(temp_directory);
-    // all_tests_passed = all_tests_passed && CPUvsGPUStatisticalOpsTest(hiv_image_80x80x1_filename, temp_directory);
+    // all_tests_passed = all_tests_passed && CPUvsGPUMaskingTest(hiv_image_80x80x1_filename, temp_directory); // these are not working due to the NPPI statistical library issues.
+    all_tests_passed = all_tests_passed && DoCPUvsGPUResize(hiv_image_80x80x1_filename, temp_directory);
+    all_tests_passed = all_tests_passed && CPUvsGPUProjectionTest(temp_directory);
+    all_tests_passed = all_tests_passed && CPUvsGPUStatisticalOpsTest(hiv_image_80x80x1_filename, temp_directory);
 #else
     wxPrintf("GPU support disabled. skipping GPU tests.\n");
 #endif


### PR DESCRIPTION
# Description

- Adds ability to do batched R2C/C2R FFTs to the GpuImage class
- Adds test for accuracy and performance on this
- Adds StopWatch method to get the ratio of elapsed time for two events (used in the performance test for example)
- Changes the half precision pointer to void and reinterprets either FP16 or BF16 to point at those to allow more flexibility in using either standard
- adds new error checking macro (cufftErr) that accurately reports the string value for a given cufftError_t enum



# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [X] yes
- [ ] no

# These changes are isolated to the

- [ ] gui
- [X] core library
- [ ] gpu core library
- [X] program it modifies

# This build was done using the cistem_build_env docker container

- [ ] yes
- [ ] no

# Checklist:

- [ ] I have not changed anything that did not need to be changed
- [X] I have performed a self-review of my own code
- [X] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
