### PR TITLE
Add more matrix tests

### DIFF
--- a/src/constants/cistem_numbers.h
+++ b/src/constants/cistem_numbers.h
@@ -1,6 +1,8 @@
 #ifndef _SRC_CONSTANTS_CISTEM_NUMBERS_H_
 #define _SRC_CONSTANTS_CISTEM_NUMBERS_H_
 
+#include <complex>
+
 #if __cplusplus > 201703L
 #include <numbers>
 using namespace std::numbers;
@@ -41,6 +43,8 @@ inline constexpr _Tp sqrt3_v = static_cast<_Tp>(1.732050807568877293527446341505
 
 template <typename _Tp>
 inline constexpr _Tp inv_sqrt3_v = _Tp(1) / sqrt3_v<_Tp>;
+
+constexpr std::complex<float> I(0.0, 1.0);
 
 #endif
 

--- a/src/core/core_headers.h
+++ b/src/core/core_headers.h
@@ -30,6 +30,7 @@ typedef struct CurvePoint {
 #define _FILE_OFFSET_BITS 64
 #endif
 
+#include "constants/constants.h"
 #include <string>
 #include <iostream>
 #include <fstream>
@@ -40,7 +41,6 @@ typedef struct CurvePoint {
 #include <cstdarg>
 #include <cfloat>
 #include <complex>
-const std::complex<float> I(0.0, 1.0);
 #include <iterator>
 #include <utility>
 #include <vector>

--- a/src/core/functions.h
+++ b/src/core/functions.h
@@ -1,36 +1,12 @@
 #include "defines.h"
+#include "non_wx_functions.h"
 
 void swapbytes(unsigned char* v, size_t n);
 void swapbytes(size_t size, unsigned char* v, size_t n);
 
 bool GetMRCDetails(const char* filename, int& x_size, int& y_size, int& number_of_images);
 
-inline void ZeroBoolArray(bool* array_to_zero, int size_of_array) {
-    for ( int counter = 0; counter < size_of_array; counter++ ) {
-        array_to_zero[counter] = false;
-    }
-}
-
-int sizeCanBe4BitK2SuperRes(int nx, int ny); // provided by David Mastronarde
-
-inline void ZeroIntArray(int* array_to_zero, int size_of_array) {
-    for ( int counter = 0; counter < size_of_array; counter++ ) {
-        array_to_zero[counter] = 0;
-    }
-}
-
-inline void ZeroLongArray(long* array_to_zero, int size_of_array) {
-    for ( int counter = 0; counter < size_of_array; counter++ ) {
-        array_to_zero[counter] = 0;
-    }
-}
-
-inline void ZeroFloatArray(float* array_to_zero, int size_of_array) {
-    for ( int counter = 0; counter < size_of_array; counter++ ) {
-        array_to_zero[counter] = 0.0;
-    }
-}
-
+int  sizeCanBe4BitK2SuperRes(int nx, int ny); // provided by David Mastronarde
 void FirstLastParticleForJob(long& first_particle, long& last_particle, long number_of_particles, int current_job_number, int number_of_jobs);
 
 int ReturnSafeBinnedBoxSize(int original_box_size, float bin_factor);
@@ -384,19 +360,6 @@ inline void ReadFromSocket	(	wxSocketBase *socket, void * 	buffer, wxUint32 nbyt
 }
 */
 
-inline void ZeroDoubleArray(double* array_to_zero, int size_of_array) {
-    for ( int counter = 0; counter < size_of_array; counter++ ) {
-        array_to_zero[counter] = 0.0;
-    }
-}
-
-inline bool IsEven(int number_to_check) {
-    if ( number_to_check % 2 == 0 )
-        return true;
-    else
-        return false;
-}
-
 inline bool DoesFileExist(wxString filename) {
     std::ifstream file_to_check(filename.c_str( ));
 
@@ -418,136 +381,8 @@ inline bool DoesFileExistWithWait(wxString filename, int max_wait_time_in_second
     return DoesFileExist(filename);
 }
 
-// Function to check if x is power of 2
-inline bool is_power_of_two(int n) {
-    if ( n == 0 )
-        return false;
-    return (ceil(log2((float)n)) == floor(log2((float)n)));
-}
-
-inline float rad_2_deg(float radians) {
-    constexpr float scale_factor = (180.f / pi_v<float>);
-    return radians * scale_factor;
-}
-
-inline float deg_2_rad(float degrees) {
-    constexpr float scale_factor = (pi_v<float> / 180.f);
-    return degrees * scale_factor;
-}
-
-inline float clamp_angular_range_0_to_2pi(float angle, bool units_are_degrees = false) {
-    // Clamps the angle to be in the range ( 0,+360 ] { exclusive, inclusive }
-    if ( units_are_degrees ) {
-        angle = fmodf(angle, 360.0f);
-    }
-    else {
-        angle = fmodf(angle, 2.0f * pi_v<float>);
-    }
-    return angle;
-}
-
-inline float clamp_angular_range_negative_pi_to_pi(float angle, bool units_are_degrees = false) {
-    // Clamps the angle to be in the range ( -180,+180 ] { exclusive, inclusive }
-    if ( units_are_degrees ) {
-        angle = fmodf(angle, 360.0f);
-        if ( angle > 180.0f )
-            angle -= 360.0f;
-        if ( angle <= -180.0f )
-            angle += 360.0f;
-        ;
-    }
-    else {
-        angle = fmodf(angle, 2.0f * pi_v<float>);
-        if ( angle > pi_v<float> )
-            angle -= 2.0f * pi_v<float>;
-        if ( angle <= -pi_v<float> )
-            angle += 2.0f * pi_v<float>;
-    }
-    return angle;
-}
-
-inline float sinc(float radians) {
-    if ( radians == 0.0 )
-        return 1.0;
-    if ( radians >= 0.01 )
-        return sinf(radians) / radians;
-    float temp_float = radians * radians;
-    return 1.0 - temp_float / 6.0 + temp_float * temp_float / 120.0;
-}
-
-inline double myround(double a) {
-    if ( a > 0 )
-        return double(long(a + 0.5));
-    else
-        return double(long(a - 0.5));
-}
-
-inline float myround(float a) {
-    if ( a > 0 )
-        return float(int(a + 0.5));
-    else
-        return float(int(a - 0.5));
-}
-
-inline int myroundint(double a) {
-    if ( a > 0 )
-        return int(a + 0.5);
-    else
-        return int(a - 0.5);
-}
-
-inline int myroundint(float a) {
-    if ( a > 0 )
-        return int(a + 0.5);
-    else
-        return int(a - 0.5);
-}
-
-inline bool IsOdd(int number) {
-    if ( (number & 1) == 0 )
-        return false;
-    else
-        return true;
-}
-
 wxArrayString ReturnIPAddress( );
 wxString      ReturnIPAddressFromSocket(wxSocketBase* socket);
-
-inline float ReturnPhaseFromShift(float real_space_shift, float distance_from_origin, float dimension_size) {
-    return real_space_shift * distance_from_origin * 2.0 * PI / dimension_size;
-}
-
-inline std::complex<float> Return3DPhaseFromIndividualDimensions(float phase_x, float phase_y, float phase_z) {
-    float temp_phase = -phase_x - phase_y - phase_z;
-
-    return cosf(temp_phase) + sinf(temp_phase) * I;
-}
-
-inline std::complex<float> MakeComplex(const float& real, const float& imag) {
-    std::complex<float> ret_val(real, imag);
-    return ret_val;
-}
-
-inline bool DoublesAreAlmostTheSame(double a, double b) {
-    return (fabs(a - b) < 0.000001);
-}
-
-inline bool FloatsAreAlmostTheSame(float a, float b) {
-    return (fabs(a - b) < 0.0001);
-}
-
-template <typename T>
-inline bool RelativeErrorIsLessThanEpsilon(T reference, T test_value, T epsilon = 0.0001) {
-    return (std::abs((reference - test_value) / reference) < epsilon);
-}
-
-inline bool InputIsATerminal( ) {
-    return isatty(fileno(stdin));
-};
-
-inline bool OutputIsAtTerminal( ) {
-    return isatty(fileno(stdout));
-}
 
 float CalculateAngularStep(float required_resolution, float radius_in_angstroms);
 
@@ -576,10 +411,6 @@ inline wxString BoolToYesNo(bool b) {
 
 long ReturnFileSizeInBytes(wxString filename);
 
-inline float kDa_to_Angstrom3(float kilo_daltons) {
-    return kilo_daltons * 1000.0 / 0.81;
-}
-
 inline bool IsAValidSymmetry(wxString* string_to_check) {
     long     junk;
     wxString buffer_string = *string_to_check;
@@ -597,18 +428,6 @@ inline bool IsAValidSymmetry(wxString* string_to_check) {
 float ReturnSumOfLogP(float logp1, float logp2, float log_range);
 
 int ReturnNumberofAsymmetricUnits(wxString symmetry);
-
-inline float ConvertProjectionXYToThetaInDegrees(float x, float y) // assumes that max x,y is 1
-{
-    return rad_2_deg(asin(sqrtf(powf(x, 2) + powf(y, 2))));
-}
-
-inline float ConvertXYToPhiInDegrees(float x, float y) {
-    if ( x == 0 && y == 0 )
-        return 0;
-    else
-        return rad_2_deg(atan2f(y, x));
-}
 
 std::vector<size_t> rankSort(const float* v_temp, const size_t size);
 std::vector<size_t> rankSort(const std::vector<float>& v_temp);
@@ -628,6 +447,10 @@ bool StripEnclosingSingleQuotesFromString(wxString& string_to_strip); // returns
 
 void ActivateMKLDebugForNonIntelCPU( ); // will activate MKL debug environment variable if running on an AMD that supports high level features.  This works on my version on intel MKL - it is disabled in the released MKL (although setting it should not break anything)
 
-inline float ReturnWavelenthInAngstroms(float kV) {
-    return 12.262643247 / sqrtf(kV * 1000 + 0.97845e-6 * powf(kV * 1000, 2));
-}
+inline bool InputIsATerminal( ) {
+    return isatty(fileno(stdin));
+};
+
+inline bool OutputIsAtTerminal( ) {
+    return isatty(fileno(stdout));
+};

--- a/src/core/non_wx_functions.h
+++ b/src/core/non_wx_functions.h
@@ -1,0 +1,192 @@
+#include <cmath>
+#include <complex>
+#include <iostream>
+#include "../constants/constants.h"
+
+inline void ZeroBoolArray(bool* array_to_zero, int size_of_array) {
+    for ( int counter = 0; counter < size_of_array; counter++ ) {
+        array_to_zero[counter] = false;
+    }
+}
+
+inline void ZeroIntArray(int* array_to_zero, int size_of_array) {
+    for ( int counter = 0; counter < size_of_array; counter++ ) {
+        array_to_zero[counter] = 0;
+    }
+}
+
+inline void ZeroLongArray(long* array_to_zero, int size_of_array) {
+    for ( int counter = 0; counter < size_of_array; counter++ ) {
+        array_to_zero[counter] = 0;
+    }
+}
+
+inline void ZeroFloatArray(float* array_to_zero, int size_of_array) {
+    for ( int counter = 0; counter < size_of_array; counter++ ) {
+        array_to_zero[counter] = 0.0;
+    }
+}
+
+inline void ZeroDoubleArray(double* array_to_zero, int size_of_array) {
+    for ( int counter = 0; counter < size_of_array; counter++ ) {
+        array_to_zero[counter] = 0.0;
+    }
+}
+
+inline bool IsEven(int number_to_check) {
+    if ( number_to_check % 2 == 0 )
+        return true;
+    else
+        return false;
+}
+
+// Function to check if x is power of 2
+inline bool is_power_of_two(int n) {
+    if ( n == 0 )
+        return false;
+    return (ceil(log2((float)n)) == floor(log2((float)n)));
+}
+
+inline float rad_2_deg(float radians) {
+    constexpr float scale_factor = (180.f / pi_v<float>);
+    return radians * scale_factor;
+}
+
+inline float deg_2_rad(float degrees) {
+    constexpr float scale_factor = (pi_v<float> / 180.f);
+    return degrees * scale_factor;
+}
+
+inline float clamp_angular_range_0_to_2pi(float angle, bool units_are_degrees = false) {
+    // Clamps the angle to be in the range ( 0,+360 ] { exclusive, inclusive }
+    if ( units_are_degrees ) {
+        angle = fmodf(angle, 360.0f);
+    }
+    else {
+        angle = fmodf(angle, 2.0f * pi_v<float>);
+    }
+    return angle;
+}
+
+inline float clamp_angular_range_negative_pi_to_pi(float angle, bool units_are_degrees = false) {
+    // Clamps the angle to be in the range ( -180,+180 ] { exclusive, inclusive }
+    if ( units_are_degrees ) {
+        angle = fmodf(angle, 360.0f);
+        if ( angle > 180.0f )
+            angle -= 360.0f;
+        if ( angle <= -180.0f )
+            angle += 360.0f;
+        ;
+    }
+    else {
+        angle = fmodf(angle, 2.0f * pi_v<float>);
+        if ( angle > pi_v<float> )
+            angle -= 2.0f * pi_v<float>;
+        if ( angle <= -pi_v<float> )
+            angle += 2.0f * pi_v<float>;
+    }
+    return angle;
+}
+
+inline float sinc(float radians) {
+    if ( radians == 0.0 )
+        return 1.0;
+    if ( radians >= 0.01 )
+        return sinf(radians) / radians;
+    float temp_float = radians * radians;
+    return 1.0 - temp_float / 6.0 + temp_float * temp_float / 120.0;
+}
+
+inline double myround(double a) {
+    if ( a > 0 )
+        return double(long(a + 0.5));
+    else
+        return double(long(a - 0.5));
+}
+
+inline float myround(float a) {
+    if ( a > 0 )
+        return float(int(a + 0.5));
+    else
+        return float(int(a - 0.5));
+}
+
+inline int myroundint(double a) {
+    if ( a > 0 )
+        return int(a + 0.5);
+    else
+        return int(a - 0.5);
+}
+
+inline int myroundint(float a) {
+    if ( a > 0 )
+        return int(a + 0.5);
+    else
+        return int(a - 0.5);
+}
+
+inline bool IsOdd(int number) {
+    if ( (number & 1) == 0 )
+        return false;
+    else
+        return true;
+}
+
+inline float ReturnPhaseFromShift(float real_space_shift, float distance_from_origin, float dimension_size) {
+    return real_space_shift * distance_from_origin * 2.0 * pi_v<float> / dimension_size;
+}
+
+inline std::complex<float> Return3DPhaseFromIndividualDimensions(float phase_x, float phase_y, float phase_z) {
+    float temp_phase = -phase_x - phase_y - phase_z;
+
+    return cosf(temp_phase) + sinf(temp_phase) * I;
+}
+
+inline std::complex<float> MakeComplex(const float& real, const float& imag) {
+    std::complex<float> ret_val(real, imag);
+    return ret_val;
+}
+
+inline bool DoublesAreAlmostTheSame(double a, double b) {
+    return (fabs(a - b) < 0.000001);
+}
+
+inline bool FloatsAreAlmostTheSame(float a, float b) {
+    return (fabs(a - b) < 0.0001);
+}
+
+template <typename T>
+bool RelativeErrorIsLessThanEpsilon(T reference, T test_value, bool print_if_failed = true, T epsilon = 0.0001) {
+
+    bool ret_val;
+    // I'm not sure if this is the best way to guard against very small division
+    if ( abs(reference) < epsilon || abs(test_value) < epsilon )
+        ret_val = (std::abs((reference - test_value)) < epsilon);
+    else
+        ret_val = (std::abs((reference - test_value) / reference) < epsilon);
+
+    if ( print_if_failed && ! ret_val ) {
+        std::cout << "RelativeErrorIsLessThanEpsilon failed: " << reference << " " << test_value << " " << epsilon << " " << std::abs((reference - test_value) / reference) << std::endl;
+    }
+    return ret_val;
+};
+
+inline float kDa_to_Angstrom3(float kilo_daltons) {
+    return kilo_daltons * 1000.0 / 0.81;
+}
+
+inline float ConvertProjectionXYToThetaInDegrees(float x, float y) // assumes that max x,y is 1
+{
+    return rad_2_deg(asin(sqrtf(powf(x, 2) + powf(y, 2))));
+}
+
+inline float ConvertXYToPhiInDegrees(float x, float y) {
+    if ( x == 0 && y == 0 )
+        return 0;
+    else
+        return rad_2_deg(atan2f(y, x));
+}
+
+inline float ReturnWavelenthInAngstroms(float kV) {
+    return 12.262643247 / sqrtf(kV * 1000 + 0.97845e-6 * powf(kV * 1000, 2));
+}

--- a/src/test/core/test_matrix.cpp
+++ b/src/test/core/test_matrix.cpp
@@ -1,7 +1,10 @@
 #include "../../core/matrix.h"
+#include "../../core/non_wx_functions.h"
 #include "../../../include/catch2/catch.hpp"
 
 TEST_CASE("RotationMatrix class", "[RotationMatrix]") {
+
+    using namespace Catch::literals;
     RotationMatrix rm;
     rm.SetToIdentity( );
     REQUIRE(rm.m[0][0] == 1.0f);
@@ -24,4 +27,38 @@ TEST_CASE("RotationMatrix class", "[RotationMatrix]") {
     REQUIRE(rm.m[2][0] == 2.0f);
     REQUIRE(rm.m[2][1] == 2.0f);
     REQUIRE(rm.m[2][2] == 2.0f);
+
+    // The rotation matrix can be set with Euler angles phi theta psi, which by themselves are used to rotate right handed coordinate systems
+    // which results in a passive transformation of image coordinates. e.g. a vector identifying a 2d coordinate is rotate into 3d and that
+    // value is interpolated and added to the 2d.
+
+    // Positive rotations clockwise about the specified axis looking down the axis towards the origin
+
+    // Z Y Z (phi theta psi)
+    rm.SetToEulerRotation(90.0f, 0.0f, 0.0f);
+    float x_in = 0.0f;
+    float y_in = 1.0f;
+    float z_in = 0.0f;
+
+    float x, y, z;
+
+    // Rotate the y axis onto the negative x axis
+    rm.RotateCoords(x_in, y_in, z_in, x, y, z);
+    REQUIRE(RelativeErrorIsLessThanEpsilon(x, -1.0f));
+    REQUIRE(RelativeErrorIsLessThanEpsilon(y, 0.0f));
+    REQUIRE(RelativeErrorIsLessThanEpsilon(z, 0.0f));
+
+    rm.SetToEulerRotation(0, 0, -90);
+    // rotate the y axis onto the positive x axis. Note This should have the same effect as if the angle were phi instead of psi
+    rm.RotateCoords(x_in, y_in, z_in, x, y, z);
+    REQUIRE(RelativeErrorIsLessThanEpsilon(x, 1.0f));
+    REQUIRE(RelativeErrorIsLessThanEpsilon(y, 0.0f));
+    REQUIRE(RelativeErrorIsLessThanEpsilon(z, 0.0f));
+
+    // obviously the z rotations should annihilate if negative of each other
+    rm.SetToEulerRotation(-90, 0, 90);
+    rm.RotateCoords(x_in, y_in, z_in, x, y, z);
+    REQUIRE(RelativeErrorIsLessThanEpsilon(x, 0.0f));
+    REQUIRE(RelativeErrorIsLessThanEpsilon(y, 1.0f));
+    REQUIRE(RelativeErrorIsLessThanEpsilon(z, 0.0f));
 }

--- a/src/test/core/test_matrix.cpp
+++ b/src/test/core/test_matrix.cpp
@@ -34,7 +34,7 @@ TEST_CASE("RotationMatrix class", "[RotationMatrix]") {
 
     // Positive rotations clockwise about the specified axis looking down the axis towards the origin
 
-    // Z Y Z (phi theta psi)
+    // Z(phi) Y(theta) Z(psi)
     rm.SetToEulerRotation(90.0f, 0.0f, 0.0f);
     float x_in = 0.0f;
     float y_in = 1.0f;
@@ -61,4 +61,26 @@ TEST_CASE("RotationMatrix class", "[RotationMatrix]") {
     REQUIRE(RelativeErrorIsLessThanEpsilon(x, 0.0f));
     REQUIRE(RelativeErrorIsLessThanEpsilon(y, 1.0f));
     REQUIRE(RelativeErrorIsLessThanEpsilon(z, 0.0f));
+
+    // combining rotations gets a little more complicated
+    // R( Z(phi) Y(theta) Z(psi) ) * vector can be interpreted as:
+    // extrinsic rotations, the rotation matrix would result in rotations about a fixed coordinate system about Z(psi) then Y(theta) then Z(phi)
+    // intrinsic rotations, the rotation matrix would result in rotations about the moving coordinate system // Z(phi) Y'(theta) Z''(psi)
+    rm.SetToEulerRotation(0, 90, 90);
+    rm.RotateCoords(x_in, y_in, z_in, x, y, z);
+    REQUIRE(RelativeErrorIsLessThanEpsilon(x, 0.0f));
+    REQUIRE(RelativeErrorIsLessThanEpsilon(y, 0.0f));
+    REQUIRE(RelativeErrorIsLessThanEpsilon(z, 1.0f));
+
+    rm.SetToEulerRotation(90, 90, 0);
+    rm.RotateCoords(x_in, y_in, z_in, x, y, z);
+    REQUIRE(RelativeErrorIsLessThanEpsilon(x, -1.0f));
+    REQUIRE(RelativeErrorIsLessThanEpsilon(y, 0.0f));
+    REQUIRE(RelativeErrorIsLessThanEpsilon(z, 0.0f));
+
+    rm.SetToEulerRotation(90, 90, -90);
+    rm.RotateCoords(x_in, y_in, z_in, x, y, z);
+    REQUIRE(RelativeErrorIsLessThanEpsilon(x, 0.0f));
+    REQUIRE(RelativeErrorIsLessThanEpsilon(y, 0.0f));
+    REQUIRE(RelativeErrorIsLessThanEpsilon(z, -1.0f));
 }


### PR DESCRIPTION
# Description

Moves useful functions out of functions.h to non_wx_functions.h to allow broader use, particularly in catch2 tests where I don't want to include the kitchen sink.

Basic test extensions for the matrix class to confirm the conventions, codified with some comments for future reference.

# Fixes 
 issue # (issue)

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [ ] yes
- [ ] no

# These changes are isolated to the

- [ ] gui
- [ ] core library
- [ ] gpu core library
- [ ] program it modifies

# This build was done using the cistem_build_env docker container

- [ ] yes
- [ ] no

# Checklist:

- [ ] I have not changed anything that did not need to be changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
