### PR TITLE
Proper random angles

### DIFF
--- a/src/constants/cistem_numbers.h
+++ b/src/constants/cistem_numbers.h
@@ -24,6 +24,12 @@ template <typename _Tp>
 inline constexpr _Tp pi_v = static_cast<_Tp>(3.141592653589793238462643383279502884L);
 
 template <typename _Tp>
+inline constexpr _Tp two_pi_v = _Tp(2) * pi_v<_Tp>;
+
+template <typename _Tp>
+inline constexpr _Tp half_pi_v = _Tp(0.5) * pi_v<_Tp>;
+
+template <typename _Tp>
 inline constexpr _Tp inv_pi_v = _Tp(1) / pi_v<_Tp>;
 
 template <typename _Tp>

--- a/src/core/euler_search.cpp
+++ b/src/core/euler_search.cpp
@@ -401,7 +401,6 @@ void EulerSearch::SetSymmetryLimits( ) {
     }
 
     theta_min_for_random_dist = cosf(deg_2_rad(theta_max));
-    _is_symmetry_limit_set    = true;
 }
 
 void EulerSearch::GetRandomEulerAngles(float& phi, float& theta, float& psi) {

--- a/src/core/euler_search.cpp
+++ b/src/core/euler_search.cpp
@@ -16,15 +16,16 @@ EulerSearch::EulerSearch( ) {
     //	best_values = NULL;
     //	starting_values = NULL;
     //parameter_map = NULL;
-    angular_step_size = 0.0;
-    phi_max           = 0.0;
-    phi_start         = 0.0;
-    theta_max         = 0.0;
-    theta_start       = 0.0;
-    psi_max           = 0.0;
-    psi_step          = 0.0;
-    psi_start         = 0.0;
-    resolution_limit  = 0.0;
+    angular_step_size         = 0.0;
+    phi_max                   = 0.0;
+    phi_start                 = 0.0;
+    theta_max                 = 0.0;
+    theta_min_for_random_dist = 0.0;
+    theta_start               = 0.0;
+    psi_max                   = 0.0;
+    psi_step                  = 0.0;
+    psi_start                 = 0.0;
+    resolution_limit          = 0.0;
     //	best_score = - std::numeric_limits<float>::max();
     test_mirror  = false;
     max_search_x = 0.0;
@@ -70,6 +71,7 @@ EulerSearch& EulerSearch::operator=(const EulerSearch* other_search) {
         phi_max                     = other_search->phi_max;
         phi_start                   = other_search->phi_start;
         theta_max                   = other_search->theta_max;
+        theta_min_for_random_dist   = other_search->theta_min_for_random_dist;
         theta_start                 = other_search->theta_start;
         psi_max                     = other_search->psi_max;
         psi_step                    = other_search->psi_step;
@@ -291,21 +293,8 @@ void EulerSearch::CalculateRandomSearchPositions( ) {
 
     if ( list_of_search_parameters != NULL )
         Deallocate2DFloatArray(list_of_search_parameters, number_of_search_positions);
-    //	{
-    //		for (i = 0; i < 2; ++i)
-    //		{
-    //			delete [] list_of_search_parameters[i];						// delete inner arrays of floats
-    //		}
-    //		delete [] list_of_search_parameters;							// delete array of pointers to float arrays
-    //	}
 
     Allocate2DFloatArray(list_of_search_parameters, number_of_search_positions, 2);
-    //	list_of_search_parameters = new float* [2];							// dynamic array (size 2) of pointers to float
-
-    //	for (i = 0; i < 2; ++i)
-    //	{
-    //		list_of_search_parameters[i] = new float[number_of_search_positions];	// each i-th pointer is now pointing to dynamic array (size number_of_positions) of actual float values
-    //	}
 
     while ( number_of_positions < number_of_search_positions ) {
         if ( parameter_map.phi ) {
@@ -348,8 +337,6 @@ void EulerSearch::SetSymmetryLimits( ) {
     wxChar symmetry_type;
     long   symmetry_number;
 
-    _is_symmetry_limit_set = true;
-
     if ( symmetry_symbol.Length( ) < 1 ) {
         MyPrintWithDetails("Error: Must specify symmetry symbol\n");
         DEBUG_ABORT;
@@ -365,58 +352,56 @@ void EulerSearch::SetSymmetryLimits( ) {
         }
     }
 
-    if ( symmetry_type == 'C' ) {
-        if ( symmetry_number == 0 ) {
-            MyPrintWithDetails("Error: Invalid n after symmetry symbol\n");
-            DEBUG_ABORT;
+    switch ( symmetry_type ) {
+        case 'C': {
+            if ( symmetry_number == 0 ) {
+                MyPrintWithDetails("Error: Invalid n after symmetry symbol\n");
+                DEBUG_ABORT;
+            }
+
+            phi_max     = 360.0 / symmetry_number;
+            theta_max   = 90.0;
+            test_mirror = true;
+            break;
         }
+        case 'D': {
+            if ( symmetry_number == 0 ) {
+                MyPrintWithDetails("Error: Invalid n after symmetry symbol\n");
+                DEBUG_ABORT;
+            }
 
-        phi_max     = 360.0 / symmetry_number;
-        theta_max   = 90.0;
-        test_mirror = true;
-
-        return;
-    }
-
-    if ( symmetry_type == 'D' ) {
-        if ( symmetry_number == 0 ) {
-            MyPrintWithDetails("Error: Invalid n after symmetry symbol\n");
-            DEBUG_ABORT;
+            phi_max     = 360.0 / symmetry_number;
+            theta_max   = 90.0;
+            test_mirror = false;
+            break;
         }
-
-        phi_max     = 360.0 / symmetry_number;
-        theta_max   = 90.0;
-        test_mirror = false;
-
-        return;
+        case 'T': {
+            phi_max     = 180.0;
+            theta_max   = 54.7;
+            test_mirror = false;
+            break;
+        }
+        case 'O': {
+            phi_max     = 90.0;
+            theta_max   = 54.7;
+            test_mirror = false;
+            break;
+        }
+        case 'I': {
+            phi_max     = 180.0;
+            theta_max   = 31.7;
+            test_mirror = false;
+            break;
+        }
+        default: {
+            MyPrintWithDetails("Error: Invalid symmetry symbol\n");
+            DEBUG_ABORT;
+            break;
+        }
     }
 
-    if ( symmetry_type == 'T' ) {
-        phi_max     = 180.0;
-        theta_max   = 54.7;
-        test_mirror = false;
-
-        return;
-    }
-
-    if ( symmetry_type == 'O' ) {
-        phi_max     = 90.0;
-        theta_max   = 54.7;
-        test_mirror = false;
-
-        return;
-    }
-
-    if ( symmetry_type == 'I' ) {
-        phi_max     = 180.0;
-        theta_max   = 31.7;
-        test_mirror = false;
-
-        return;
-    }
-
-    MyPrintWithDetails("Error: Invalid symmetry symbol\n");
-    DEBUG_ABORT;
+    theta_min_for_random_dist = cosf(deg_2_rad(theta_max));
+    _is_symmetry_limit_set    = true;
 }
 
 void EulerSearch::GetRandomEulerAngles(float& phi, float& theta, float& psi) {
@@ -424,9 +409,10 @@ void EulerSearch::GetRandomEulerAngles(float& phi, float& theta, float& psi) {
 
     phi = _my_rand.GetUniformRandomSTD(0.f, phi_max);
     // The upper bound is not inclusive so acosf will be inbounds
-    theta = acosf(2.f * _my_rand.GetUniformRandomSTD(0.f, 1.f) - 1.f);
-    theta = fmodf(rad_2_deg(phi), theta_max);
-    psi   = _my_rand.GetUniformRandomSTD(0.f, 360.f);
+    // to get theta 0-pi acosf -1.0 to 1.0
+    theta = rad_2_deg(acosf(_my_rand.GetUniformRandomSTD(theta_min_for_random_dist, 1.f)));
+
+    psi = _my_rand.GetUniformRandomSTD(0.f, 360.f);
 }
 
 /**

--- a/src/core/euler_search.cpp
+++ b/src/core/euler_search.cpp
@@ -29,6 +29,8 @@ EulerSearch::EulerSearch( ) {
     test_mirror  = false;
     max_search_x = 0.0;
     max_search_y = 0.0;
+
+    _is_symmetry_limit_set = false;
 }
 
 EulerSearch::EulerSearch(const EulerSearch& other_search) // copy constructor
@@ -76,6 +78,7 @@ EulerSearch& EulerSearch::operator=(const EulerSearch* other_search) {
         parameter_map               = other_search->parameter_map;
         test_mirror                 = other_search->test_mirror;
         symmetry_symbol             = other_search->symmetry_symbol;
+        _is_symmetry_limit_set      = other_search->_is_symmetry_limit_set;
 
         if ( list_of_search_parameters != NULL )
             Deallocate2DFloatArray(list_of_search_parameters, number_of_search_positions);
@@ -345,6 +348,8 @@ void EulerSearch::SetSymmetryLimits( ) {
     wxChar symmetry_type;
     long   symmetry_number;
 
+    _is_symmetry_limit_set = true;
+
     if ( symmetry_symbol.Length( ) < 1 ) {
         MyPrintWithDetails("Error: Must specify symmetry symbol\n");
         DEBUG_ABORT;
@@ -412,6 +417,16 @@ void EulerSearch::SetSymmetryLimits( ) {
 
     MyPrintWithDetails("Error: Invalid symmetry symbol\n");
     DEBUG_ABORT;
+}
+
+void EulerSearch::GetRandomEulerAngles(float& phi, float& theta, float& psi) {
+    MyDebugAssertTrue(_is_symmetry_limit_set, "Symmetry limits not set");
+
+    phi = _my_rand.GetUniformRandomSTD(0.f, phi_max);
+    // The upper bound is not inclusive so acosf will be inbounds
+    theta = acosf(2.f * _my_rand.GetUniformRandomSTD(0.f, 1.f) - 1.f);
+    theta = fmodf(rad_2_deg(phi), theta_max);
+    psi   = _my_rand.GetUniformRandomSTD(0.f, 360.f);
 }
 
 /**

--- a/src/core/euler_search.h
+++ b/src/core/euler_search.h
@@ -2,9 +2,16 @@
 #define _SRC_CORE_EULER_SEARCH_H_
 #include <cistem_config.h>
 
+#include "../constants/cistem_numbers.h"
+
 class GpuImage;
 
 class EulerSearch {
+
+  private:
+    bool                  _is_symmetry_limit_set;
+    RandomNumberGenerator _my_rand{pi_v<float>};
+
     // Brute-force search to find matching projections
 
   public:
@@ -63,8 +70,11 @@ class EulerSearch {
     void                         CalculateGridSearchPositions(bool random_start_angle = true);
 #endif
 
+    // TODO: make this use the newer GetRandomEulerAngles() which evenly sample the euler sphere
     void CalculateRandomSearchPositions( );
     void SetSymmetryLimits( );
+    void GetRandomEulerAngles(float& phi, float& theta, float& psi);
+
     //	void RotateFourier2DFromIndex(Image &image_to_rotate, Image &rotated_image, Kernel2D &kernel_index);
     //	void RotateFourier2DIndex(Image &image_to_rotate, Kernel2D &kernel_index, AnglesAndShifts &rotation_angle, float resolution_limit = 1.0, float padding_factor = 1.0);
     Kernel2D ReturnLinearInterpolatedFourierKernel2D(Image& image_to_rotate, float& x, float& y);

--- a/src/core/euler_search.h
+++ b/src/core/euler_search.h
@@ -25,6 +25,7 @@ class EulerSearch {
     float   phi_max;
     float   phi_start;
     float   theta_max;
+    float   theta_min_for_random_dist;
     float   theta_start;
     float   psi_max;
     float   psi_step;

--- a/src/core/pdb.cpp
+++ b/src/core/pdb.cpp
@@ -837,6 +837,7 @@ void PDB::TransformLocalAndCombine(PDB* pdb_ensemble, int number_of_pdbs, int fr
      * Take an array of PDB objects and create a single array of atoms transformed according to the timestep
     */
     // wxPrintf("\n\nTransforming local and combining\n");
+    // std::cerr << " My size their size " << atoms.size( ) << " dd " << pdb_ensemble->atoms.size( ) << std::endl;
 
     int   current_pdb        = 0;
     int   current_particle   = 0;
@@ -864,7 +865,8 @@ void PDB::TransformLocalAndCombine(PDB* pdb_ensemble, int number_of_pdbs, int fr
         if ( this->atoms.capacity( ) < pdb_ensemble[current_pdb].number_of_atoms ) {
             this->atoms.reserve(pdb_ensemble[current_pdb].number_of_atoms);
         }
-        // wxPrintf("Checking %ld %ld\n", pdb_ensemble[current_pdb].atoms.size( ), atoms.size( ));
+        wxPrintf("Checking %ld %ld\n", pdb_ensemble[current_pdb].atoms.size( ), atoms.size( ));
+        std::cerr << " number of particles intialized " << pdb_ensemble[current_pdb].number_of_particles_initialized << std::endl;
         for ( current_particle = 0; current_particle < pdb_ensemble[current_pdb].number_of_particles_initialized; current_particle++ ) {
             ox = pdb_ensemble[current_pdb].my_trajectory.Item(current_particle).current_orientation[0][0];
             oy = pdb_ensemble[current_pdb].my_trajectory.Item(current_particle).current_orientation[0][1];
@@ -937,9 +939,9 @@ void PDB::TransformLocalAndCombine(PDB* pdb_ensemble, int number_of_pdbs, int fr
                 }
             }
             else {
-
+                this->atoms.clear( );
                 for ( current_atom = 0; current_atom < pdb_ensemble[current_pdb].number_of_atoms; current_atom++ ) {
-                    this->atoms[current_atom] = (pdb_ensemble[current_pdb].atoms[current_atom]);
+                    this->atoms.push_back(pdb_ensemble[current_pdb].atoms[current_atom]);
                 }
 
                 if ( pdb_ensemble[current_pdb].generate_noise_atoms && frame_number == 0 ) {

--- a/src/core/pdb.cpp
+++ b/src/core/pdb.cpp
@@ -865,8 +865,7 @@ void PDB::TransformLocalAndCombine(PDB* pdb_ensemble, int number_of_pdbs, int fr
         if ( this->atoms.capacity( ) < pdb_ensemble[current_pdb].number_of_atoms ) {
             this->atoms.reserve(pdb_ensemble[current_pdb].number_of_atoms);
         }
-        wxPrintf("Checking %ld %ld\n", pdb_ensemble[current_pdb].atoms.size( ), atoms.size( ));
-        std::cerr << " number of particles intialized " << pdb_ensemble[current_pdb].number_of_particles_initialized << std::endl;
+        // wxPrintf("Checking %ld %ld\n", pdb_ensemble[current_pdb].atoms.size( ), atoms.size( ));
         for ( current_particle = 0; current_particle < pdb_ensemble[current_pdb].number_of_particles_initialized; current_particle++ ) {
             ox = pdb_ensemble[current_pdb].my_trajectory.Item(current_particle).current_orientation[0][0];
             oy = pdb_ensemble[current_pdb].my_trajectory.Item(current_particle).current_orientation[0][1];
@@ -939,6 +938,8 @@ void PDB::TransformLocalAndCombine(PDB* pdb_ensemble, int number_of_pdbs, int fr
                 }
             }
             else {
+                // TODO: consider using the assignment instead
+                // this->atoms = pdb_ensemble[current_pdb].atoms;
                 this->atoms.clear( );
                 for ( current_atom = 0; current_atom < pdb_ensemble[current_pdb].number_of_atoms; current_atom++ ) {
                     this->atoms.push_back(pdb_ensemble[current_pdb].atoms[current_atom]);

--- a/src/core/scattering_potential.cpp
+++ b/src/core/scattering_potential.cpp
@@ -88,21 +88,21 @@ void ScatteringPotential::InitPdbEnsemble(bool              shift_by_center_of_m
 
     for ( int iPDB = 0; iPDB < pdb_file_names.size( ); iPDB++ ) {
 
-        pdb_ensemble[iPDB] = PDB(pdb_file_names[iPDB],
-                                 access_type_read,
-                                 _pixel_size,
-                                 records_per_line,
-                                 minimum_padding_x_and_y,
-                                 minimum_thickness_z,
-                                 max_number_of_noise_particles,
-                                 wanted_noise_particle_radius_as_mutliple_of_particle_radius,
-                                 wanted_noise_particle_radius_randomizer_lower_bound_as_praction_of_particle_radius,
-                                 wanted_noise_particle_radius_randomizer_upper_bound_as_praction_of_particle_radius,
-                                 wanted_tilt_angle_to_emulate,
-                                 shift_by_center_of_mass,
-                                 is_alpha_fold_prediction,
-                                 wanted_star_file,
-                                 use_star_file);
+        pdb_ensemble.emplace_back(pdb_file_names[iPDB],
+                                  access_type_read,
+                                  _pixel_size,
+                                  records_per_line,
+                                  minimum_padding_x_and_y,
+                                  minimum_thickness_z,
+                                  max_number_of_noise_particles,
+                                  wanted_noise_particle_radius_as_mutliple_of_particle_radius,
+                                  wanted_noise_particle_radius_randomizer_lower_bound_as_praction_of_particle_radius,
+                                  wanted_noise_particle_radius_randomizer_upper_bound_as_praction_of_particle_radius,
+                                  wanted_tilt_angle_to_emulate,
+                                  shift_by_center_of_mass,
+                                  is_alpha_fold_prediction,
+                                  wanted_star_file,
+                                  use_star_file);
     }
 }
 
@@ -226,7 +226,6 @@ void ScatteringPotential::calc_scattering_potential(const PDB* current_specimen,
         n_atoms_added = 0;
 
         atom_id = current_specimen->atoms.at(current_atom).atom_type;
-        // std::cerr << "atom_id = " << atom_id << std::endl;
         if ( atom_id == hydrogen )
             continue;
 

--- a/src/core/water.cpp
+++ b/src/core/water.cpp
@@ -112,6 +112,13 @@ void Water::Init(const PDB* current_specimen, int wanted_size_neighborhood, floa
     this->vol_oZ = floor(this->vol_nZ / 2);
 }
 
+/**
+ * @brief Water::SeedWaters3d
+ * This method randomly seeds water (or carbon) based on the density of the amorphous material. With this implmentation, at most 4 waters may be assigned
+ * to each voxel, such that the linear pixel size must be > 0.0394 Angstroms = 0.03142 / 8 cubic Ang volume = density of LDA.
+ * @param n_waters_lower_bound
+ * @param random_sigma_cutoff
+ */
 void Water::SeedWaters3d( ) {
 
     // Volume in Ang / (ang^3/nm^3 * nm^3/nWaters) buffer by 10%
@@ -127,23 +134,22 @@ void Water::SeedWaters3d( ) {
     }
 
     wxPrintf("Atoms per nm^3 %3.3f, vol (in Ang^3) %2.2f %2.2f %2.2f\n", waters_per_angstrom_cubed * 1000, this->vol_angX, this->vol_angY, this->vol_angZ);
-    double n_waters_lower_bound = waters_per_angstrom_cubed * (this->vol_angX * this->vol_angY * this->vol_angZ);
-    long   n_waters_possible    = (long)floor(1.1 * n_waters_lower_bound); // maybe make this a real vector so it is extensible.
-    // wxPrintf("specimen volume is %3.3e nm expecting %3.3e waters\n",(this->vol_angX * this->vol_angY * this->vol_angZ)/1000,n_waters_lower_bound);
+    const float n_waters_lower_bound = waters_per_angstrom_cubed * (this->vol_angX * this->vol_angY * this->vol_angZ);
+    // FIXME:: this estimate should be more accurate
+    long n_waters_possible = (long)floor(1.05 * n_waters_lower_bound); // maybe make this a real vector so it is extensible.
+    wxPrintf("specimen volume is %3.3e nm expecting %3.3e waters\n", (this->vol_angX * this->vol_angY * this->vol_angZ) / 1000, n_waters_lower_bound);
 
     RandomNumberGenerator my_rand(pi_v<float>);
 
-    // FIXME is the multiplication by pixel size correct? I am not so sure.
-    const float random_sigma_cutoff   = 1 - (n_waters_lower_bound / double((this->vol_nX - (this->size_neighborhood * this->pixel_size)) *
-                                                                         (this->vol_nY - (this->size_neighborhood * this->pixel_size)) *
-                                                                         (this->vol_nZ - (this->size_neighborhood * this->pixel_size))));
-    const float random_sigma_negativo = -1 * random_sigma_cutoff;
-    float       current_random;
-    const float random_sigma = 0.5 / this->pixel_size; // random shift in pixel values
-    float       thisRand;
-    // wxPrintf("cuttoff is %2.6e %2.6e %f %f\n",n_waters_lower_bound,double((this->vol_nX - this->size_neighborhood) *
-    // 																	  (this->vol_nY - this->size_neighborhood) *
-    // 		 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	  (this->vol_nZ - this->size_neighborhood)), random_sigma_cutoff, random_sigma_negativo);
+    // // We want to add waters with a density == n_waters_lower_bound / volume in angstroms
+    // const float random_sigma_cutoff   = 1 - (n_waters_lower_bound / double((this->vol_nX - (this->size_neighborhood * this->pixel_size)) *
+    //                                                                      (this->vol_nY - (this->size_neighborhood * this->pixel_size)) *
+    //                                                                      (this->vol_nZ - (this->size_neighborhood * this->pixel_size))));
+
+    // We want to add waters with a density == n_waters_lower_bound / volume in angstroms
+    const float probablity_of_water_in_voxel_octent = 1 - n_waters_lower_bound / float(this->vol_nX * this->vol_nY * this->vol_nZ * 8);
+
+    std::cerr << "probablity_of_water_in_voxel_octent " << probablity_of_water_in_voxel_octent << std::endl;
 
     water_coords.reserve(n_waters_possible);
     is_allocated_water_coords = true;
@@ -156,40 +162,44 @@ void Water::SeedWaters3d( ) {
     // Break up the x/y dims into ~ nThreads^2 thread blocks
     int incX = ceil(vol_nX / nThreads);
     int incY = ceil(vol_nY / nThreads);
-    int iLower, iUpper, jLower, jUpper, xUpper, yUpper;
+    int iLower, iUpper, jLower, jUpper; //, xUpper, yUpper;
 
-    xUpper = this->vol_nX - this->size_neighborhood;
-    yUpper = this->vol_nY - this->size_neighborhood;
+    // xUpper = this->vol_nX - this->size_neighborhood;
+    // yUpper = this->vol_nY - this->size_neighborhood;
 
+    // The outer two loops are over the blocks in x/y that should be handled by each thread.
+    // This logic falls apart as the specimen is tilted. FIXME
     for ( int i = 0; i < nThreads; i++ ) {
-        iLower = i * incX + size_neighborhood;
-        iUpper = (1 + i) * incX + size_neighborhood;
+        iLower = i * incX;
+        iUpper = iLower + incX;
         for ( int j = 0; j < nThreads; j++ ) {
-            jLower = j * incY + size_neighborhood;
-            jUpper = (1 + j) * incY + size_neighborhood;
+            jLower = j * incY;
+            jUpper = jLower + incY;
 
-            //			for (int k = this->size_neighborhood; k < this->vol_nZ - this->size_neighborhood; k++)
-            for ( int k = 0; k < this->vol_nZ; k++ )
-
-            {
+            // For each block
+            for ( int k = 0; k < this->vol_nZ; k++ ) {
                 for ( int iInner = iLower; iInner < iUpper; iInner++ ) {
-                    //					if (iInner > xUpper) { continue; }
                     for ( int jInner = jLower; jInner < jUpper; jInner++ ) {
-                        //						if (jInner > yUpper) { continue; }
 
-                        if ( my_rand.GetUniformRandomSTD(0.0, 1.0) > random_sigma_cutoff ) {
-
-                            water_coords.emplace_back(AtomType::water, float(iInner), float(jInner), float(k));
-                            // water_coords[number_of_waters].x = (float)iInner;
-                            // water_coords[number_of_waters].y = (float)jInner;
-                            // water_coords[number_of_waters].z = (float)k;
-                            number_of_waters++;
+                        // For each sub-voxel octant
+                        for ( float qz = -0.5f; qz <= 0.5f; qz += 1.f ) {
+                            for ( float qy = -0.5f; qy <= 0.5f; qy += 1.f ) {
+                                for ( float qx = -0.5f; qx <= 0.5f; qx += 1.f ) {
+                                    if ( my_rand.GetUniformRandomSTD(0.0, 1.0) > probablity_of_water_in_voxel_octent )
+                                        water_coords.emplace_back(AtomType::water, float(iInner) + qx, float(jInner) + qy, float(k) + qz);
+                                }
+                            }
                         }
                     }
                 }
             }
         }
     }
+
+    // We won't add any more waters, so free up the extra memory
+    // TODO: does freeing cost more than leaving it be?
+    water_coords.shrink_to_fit( );
+    number_of_waters = water_coords.size( );
 
     wxPrintf("waters added %3.3e (%2.2f%)\n", (float)this->number_of_waters, 100.0f * (float)this->number_of_waters / n_waters_lower_bound);
 }

--- a/src/core/water.cpp
+++ b/src/core/water.cpp
@@ -19,9 +19,6 @@ Water::Water(const PDB* current_specimen, int wanted_size_neighborhood, float wa
 }
 
 Water::~Water( ) {
-    if ( is_allocated_water_coords ) {
-        delete[] water_coords;
-    }
 }
 
 void Water::Init(const PDB* current_specimen, int wanted_size_neighborhood, float wanted_pixel_size, float wanted_dose_per_frame, RotationMatrix max_rotation, float in_plane_rotation, int* padX, int* padY, int nThreads, bool pad_based_on_rotation) {
@@ -148,7 +145,7 @@ void Water::SeedWaters3d( ) {
     // 																	  (this->vol_nY - this->size_neighborhood) *
     // 		 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	  (this->vol_nZ - this->size_neighborhood)), random_sigma_cutoff, random_sigma_negativo);
 
-    water_coords              = new AtomPos[n_waters_possible];
+    water_coords.reserve(n_waters_possible);
     is_allocated_water_coords = true;
 
     //  There are millions to billions of waters. We want to schedule the threads in a way that avoids atomic collisions
@@ -182,9 +179,10 @@ void Water::SeedWaters3d( ) {
 
                         if ( my_rand.GetUniformRandomSTD(0.0, 1.0) > random_sigma_cutoff ) {
 
-                            water_coords[number_of_waters].x = (float)iInner;
-                            water_coords[number_of_waters].y = (float)jInner;
-                            water_coords[number_of_waters].z = (float)k;
+                            water_coords.emplace_back(AtomType::water, float(iInner), float(jInner), float(k));
+                            // water_coords[number_of_waters].x = (float)iInner;
+                            // water_coords[number_of_waters].y = (float)jInner;
+                            // water_coords[number_of_waters].z = (float)k;
                             number_of_waters++;
                         }
                     }

--- a/src/core/water.h
+++ b/src/core/water.h
@@ -3,11 +3,16 @@
 
 #include "../constants/electron_scattering.h"
 
+// TODO: this could be a short and half-precision type
 typedef struct __attribute__((packed)) __attribute__((aligned(16))) _AtomPos {
     AtomType atom_id;
     float    x;
     float    y;
     float    z;
+
+    _AtomPos( ) : atom_id(hydrogen), x(0.f), y(0.f), z(0.f) {}
+
+    _AtomPos(AtomType _a, float _x, float _y, float _z) : atom_id(_a), x(_x), y(_y), z(_z) {}
 
 } AtomPos;
 
@@ -25,26 +30,26 @@ class Water {
 
     // data
 
-    long     number_of_waters = 0;
-    int      size_neighborhood;
-    float    pixel_size;
-    float    dose_per_frame;
-    int      records_per_line;
-    int      number_of_time_steps;
-    bool     simulate_phase_plate;
-    bool     keep_time_steps;
-    double   center_of_mass[3];
-    long     number_of_each_atom[cistem::number_of_atom_types];
-    float    atomic_volume;
-    float    vol_angX, vol_angY, vol_angZ;
-    int      vol_nX, vol_nY, vol_nZ;
-    float    vol_oX, vol_oY, vol_oZ;
-    float    offset_z;
-    float    min_z;
-    float    max_z;
-    AtomPos* water_coords;
-    bool     is_allocated_water_coords = false;
-    int      nThreads;
+    long                 number_of_waters = 0;
+    int                  size_neighborhood;
+    float                pixel_size;
+    float                dose_per_frame;
+    int                  records_per_line;
+    int                  number_of_time_steps;
+    bool                 simulate_phase_plate;
+    bool                 keep_time_steps;
+    double               center_of_mass[3];
+    long                 number_of_each_atom[cistem::number_of_atom_types];
+    float                atomic_volume;
+    float                vol_angX, vol_angY, vol_angZ;
+    int                  vol_nX, vol_nY, vol_nZ;
+    float                vol_oX, vol_oY, vol_oZ;
+    float                offset_z;
+    float                min_z;
+    float                max_z;
+    std::vector<AtomPos> water_coords;
+    bool                 is_allocated_water_coords = false;
+    int                  nThreads;
 
     //	void set_initial_trajectories(PDB *pdb_ensemble);
 

--- a/src/programs/quick_test/quick_test.cpp
+++ b/src/programs/quick_test/quick_test.cpp
@@ -44,6 +44,19 @@ bool QuickTestApp::DoCalculation( ) {
     my_rotation_matrix.SetToEulerRotation(-l_psi, -l_theta, -l_phi);
     my_symmetry_matrix.Init("C1");
 
+    ParameterMap my_dummy_map;
+    EulerSearch  my_angle_restrictions;
+    my_angle_restrictions.InitGrid(symmetry_symbol, 0.5, 0., 0., 360, 1.5, 0., 1.0f * 2, my_dummy_map, 5);
+    NumericTextFile my_results_file("results.txt", OPEN_TO_WRITE, 3);
+    float           r[3];
+    for ( int i = 0; i < 10000; i++ ) {
+        my_angle_restrictions.GetRandomEulerAngles(l_phi, l_theta, l_psi);
+        my_rotation_matrix.SetToEulerRotation(l_phi, l_theta, 0);
+
+        my_rotation_matrix.RotateCoords(0.f, 0.f, 1.f, r[0], r[1], r[2]);
+        my_results_file.WriteLine(r);
+    }
+    exit(1);
     for ( int theta = -4; theta < 5; theta++ ) {
         float my_theta = float(theta * 5.f);
         other_rotation_matrix.SetToEulerRotation(-l_psi, -l_theta + my_theta, -l_phi);

--- a/src/programs/simulate/simulate.cpp
+++ b/src/programs/simulate/simulate.cpp
@@ -744,6 +744,8 @@ bool SimulateApp::DoCalculation( ) {
         exit(-1);
     }
 
+    sp.SetImagingParameters(wanted_pixel_size, kV);
+
     if ( make_particle_stack > 0 ) {
 
         sp.InitPdbEnsemble(SHIFT_BY_CENTER_OF_MASS, minimum_padding_x_and_y, minimum_thickness_z,
@@ -1499,12 +1501,10 @@ void SimulateApp::probability_density_2d(PDB* pdb_ensemble, int time_step) {
                 scattering_potential[iSlab].SetToConstant(0.0f);
                 coords.Allocate(&inelastic_potential[iSlab], (PaddingStatus)solvent, true, true);
 
-                //            inelastic_potential[iSlab].Allocate(current_specimen.vol_nX, current_specimen.vol_nY,1);
                 inelastic_potential[iSlab].SetToConstant(0.0f);
 
                 if ( SAVE_REF ) {
                     coords.Allocate(&ref_potential[iSlab], (PaddingStatus)solvent, true, true);
-                    //                ref_potential[iSlab].Allocate(current_specimen.vol_nX, current_specimen.vol_nY,1);
                 }
 
                 slab_nZ    = slabIDX_end[iSlab] - slabIDX_start[iSlab] + 1; // + 2*this->size_neighborhood;


### PR DESCRIPTION
# Description

Adds 2pi and pi/2 to cistem::numbers

EulerSearch::GetRandomEulerAngles(float& phi, float& theta, float& psi)

change ScatteringPotential::InitPdbEnsemble to use emplace back instead of push_back

change Water::SeedWaters3d to use a vector for water_coords, and subsample every voxel by 8 to ensure the desired number of waters better matches the expected number of waters via density. Side benefit is an additionaly layer of randomization

Fix simulate to work with new ScatteringPotential (the imaging parameters need to be set prior to )

# Fixes 
 issue # (issue)

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [ ] yes
- [ ] no

# These changes are isolated to the

- [ ] gui
- [ ] core library
- [ ] gpu core library
- [ ] program it modifies

# This build was done using the cistem_build_env docker container

- [ ] yes
- [ ] no

# Checklist:

- [ ] I have not changed anything that did not need to be changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
