### PR TITLE
Everything but cufft which still must be static for callbacks.

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -2,7 +2,7 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.230.0/containers/ubuntu
 {
     // "name": "cisTEMx-0.1",
-    "image": "bhimesbhimes/cistem_build_env:v1.4.5",
+    "image": "bhimesbhimes/cistem_build_env:v1.5.0",
     // Set *default* container specific settings.json values on container create.
     "settings": {},
     // Add the IDs of extensions you want installed when the container is created.

--- a/.devcontainer_build/Dockerfile
+++ b/.devcontainer_build/Dockerfile
@@ -14,6 +14,11 @@ RUN pip3 install gdown && cd / && gdown https://drive.google.com/drive/folders/1
 #     rm -rf /var/lib/apt/lists/*  && \
 #     npm install -g pnpm
 
+# TODO: move this to the base container once we confirm dynamic linking is working okay
+# Use the basename bit to ensure no rm -rf foibles with root dir in empyt string case
+RUN ls /usr/local/cuda/targets/x86_64-linux/lib/lib*_static.a | grep -v cufft_static.a | while read a; do rm -rf /usr/local/cuda/targets/x86_64-linux/lib/$(basename $a); done
+RUN rm -f /usr/local/cuda/targets/x86_64-linux/lib/libcufft_static_nocallback.a
+
 
 # Install cutensor
 ARG CUTENSOR_VERSION=libcutensor-linux-x86_64-1.6.0.3-archive

--- a/.devcontainer_build/Dockerfile
+++ b/.devcontainer_build/Dockerfile
@@ -1,11 +1,11 @@
-FROM bhimesbhimes/cistem_build_env:base_image_v1.4.5
+FROM bhimesbhimes/cistem_build_env:base_image_v1.5.0
 
 # some rebuild comment
 
-ENV CISTEM_REF_IMAGES /cistem_reference_images
+ENV CISTEM_REF_IMAGES /cisTEMx/cistem_reference_images
 
 # Get reference images for testing and debugging
-RUN pip3 install gdown && cd / && gdown https://drive.google.com/drive/folders/1PO9tBU7lKqKUuSb8qdEPvlEk7xeektXv?usp --folder
+RUN mkdir -p /cisTEMx && pip3 install gdown && cd /cisTEMx && gdown https://drive.google.com/drive/folders/1PO9tBU7lKqKUuSb8qdEPvlEk7xeektXv?usp --folder
 
 
 # # Install Node 16
@@ -14,21 +14,7 @@ RUN pip3 install gdown && cd / && gdown https://drive.google.com/drive/folders/1
 #     rm -rf /var/lib/apt/lists/*  && \
 #     npm install -g pnpm
 
-# TODO: move this to the base container once we confirm dynamic linking is working okay
-# Use the basename bit to ensure no rm -rf foibles with root dir in empyt string case
-RUN ls /usr/local/cuda/targets/x86_64-linux/lib/lib*_static.a | grep -v cufft_static.a | while read a; do rm -rf /usr/local/cuda/targets/x86_64-linux/lib/$(basename $a); done
-RUN rm -f /usr/local/cuda/targets/x86_64-linux/lib/libcufft_static_nocallback.a
 
-
-# Install cutensor
-ARG CUTENSOR_VERSION=libcutensor-linux-x86_64-1.6.0.3-archive
-ARG CUTENSOR_LIB=11
-RUN cd /tmp &&   wget https://developer.download.nvidia.com/compute/cutensor/redist/libcutensor/linux-x86_64/${CUTENSOR_VERSION}.tar.xz && \
-    mkdir /opt/cuTensor && tar -xf ${CUTENSOR_VERSION}.tar.xz --strip 1 -C /opt/cuTensor && \
-    cd /opt/cuTensor/lib && ln -s ${CUTENSOR_LIB} cistem_version && \
-    rm -rf 10.2 ${CUTENSORLIB}/libcuten*_static.a && \
-    echo 'export CUTENSOR_ROOT=/opt/cuTensor' >> /home/cisTEMx/.bashrc && \ 
-    echo 'export LD_LIBRARY_PATH=${CUTENSOR_ROOT}/lib/cistem_version/:${LD_LIBRARY_PATH}' >> /home/cisTEMx/.bashrc 
 
 
 

--- a/.devcontainer_build/Dockerfile
+++ b/.devcontainer_build/Dockerfile
@@ -21,8 +21,9 @@ ARG CUTENSOR_LIB=11
 RUN cd /tmp &&   wget https://developer.download.nvidia.com/compute/cutensor/redist/libcutensor/linux-x86_64/${CUTENSOR_VERSION}.tar.xz && \
     mkdir /opt/cuTensor && tar -xf ${CUTENSOR_VERSION}.tar.xz --strip 1 -C /opt/cuTensor && \
     cd /opt/cuTensor/lib && ln -s ${CUTENSOR_LIB} cistem_version && \
+    rm -rf 10.2 ${CUTENSORLIB}/libcuten*_static.a && \
     echo 'export CUTENSOR_ROOT=/opt/cuTensor' >> /home/cisTEMx/.bashrc && \ 
-    echo 'export LD_LIBRARY_PATH=${CUTENSOR_ROOT}/lib/${cistem_version}/:${LD_LIBRARY_PATH}' >> /home/cisTEMx/.bashrc 
+    echo 'export LD_LIBRARY_PATH=${CUTENSOR_ROOT}/lib/cistem_version/:${LD_LIBRARY_PATH}' >> /home/cisTEMx/.bashrc 
 
 
 

--- a/.github/workflows/run_builds.yml
+++ b/.github/workflows/run_builds.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: true
     runs-on: ${{ inputs.runs_on_os }}
     container: 
-      image: bhimesbhimes/cistem_build_env:v1.4.5
+      image: bhimesbhimes/cistem_build_env:v1.5.0
       options: --user root --rm --gpus all
     outputs:
       version: ${{ steps.configure.outputs.version }}

--- a/ax_cuda.m4
+++ b/ax_cuda.m4
@@ -97,14 +97,14 @@ if test "$want_cuda" = "yes" ; then
   	libdir=lib64
 
 	# set CUDA flags for static compilation. This is required for cufft callbacks.
-	# Note: lcutensor_static requires lcublasLt_static and it must be listed *after* it in the li nk line.
+	# Note: lcutensor requires lcublasLt and it must be listed *after* it in the li nk line.
 	if test -n "$cuda_home_path"
 	then
 	  CUDA_CFLAGS="-I$cuda_home_path/include -I/opt/cuTensor/include"
-      CUDA_LIBS="-L/opt/cuTensor/lib/cistem_version -L$cuda_home_path/$libdir -lcufft_static -lnppial_static -lnppist_static -lnppc_static -lnppidei_static -lnppitc_static -lcurand_static  -lcutensor_static -lcublasLt_static -lculibos -lcudart_static -lrt"
+      CUDA_LIBS="-L/opt/cuTensor/lib/cistem_version -L$cuda_home_path/$libdir -lcufft_static -lnppial -lnppist -lnppc -lnppidei -lnppitc -lcurand  -lcutensor -lcublasLt -lculibos -lcudart -lrt"
 	else
 	  CUDA_CFLAGS="-I/usr/local/cuda/include -I/opt/cuTensor/include"
-	  CUDA_LIBS="-L/opt/cuTensor/lib/cistem_version -L/usr/local/cuda/$libdir -lcufft_static -lnppial_static -lnppist_static -lnppc_static -lnppidei_static -lnppitc_static -lcurand_static  -lcutensor_static -lcublasLt_static -lculibos -lcudart_static -lrt"
+	  CUDA_LIBS="-L/opt/cuTensor/lib/cistem_version -L/usr/local/cuda/$libdir -lcufft_static -lnppial -lnppist -lnppc -lnppidei -lnppitc -lcurand  -lcutensor -lcublasLt -lculibos -lcudart -lrt"
 	fi
 
 

--- a/scripts/containers/base_image/Dockerfile
+++ b/scripts/containers/base_image/Dockerfile
@@ -103,8 +103,20 @@ RUN cd /tmp && wget https://download.pytorch.org/libtorch/cu113/libtorch-cxx11-a
     rm libtorch-cxx11-abi-shared-with-deps-1.11.0+cu113.zip && \
     mv libtorch /opt
 
+# Install cutensor
+ARG CUTENSOR_VERSION=libcutensor-linux-x86_64-1.6.0.3-archive
+ARG CUTENSOR_LIB=11
+RUN cd /tmp &&   wget https://developer.download.nvidia.com/compute/cutensor/redist/libcutensor/linux-x86_64/${CUTENSOR_VERSION}.tar.xz && \
+    mkdir /opt/cuTensor && tar -xf ${CUTENSOR_VERSION}.tar.xz --strip 1 -C /opt/cuTensor && \
+    cd /opt/cuTensor/lib && \
+    ls -d | grep -v ${CUTENSOR_VERSION} | grep -v "." | grep -v ".." | while read not_version; do rm -rf /opt/cuTensor/lib/${not_version} ; done && \
+    ln -s ${CUTENSOR_LIB} cistem_version && \
+    rm -f ${CUTENSOR_LIB}/libcuten*_static.a && \
+    echo 'export CUTENSOR_ROOT=/opt/cuTensor' >> /home/cisTEMx/.bashrc 
+
 # Include the lib path in LD_RUN_PATH so on linking, the correct path is known 
-ENV LD_RUN_PATH=/opt/libtorch/lib:${LD_RUN_PATH}
+
+ENV LD_RUN_PATH=/opt/cuTensor/lib/cistem_version:/usr/local/cuda/lib64:/opt/libtorch/lib:${LD_RUN_PATH}
 
 
 # Install cuda (when the web is live)
@@ -114,7 +126,12 @@ ARG DRIVER_VER=515.43.04
 RUN cd /tmp && wget https://developer.download.nvidia.com/compute/cuda/${CUDA_VER}/local_installers/cuda_${CUDA_VER}_${DRIVER_VER}_linux.run && \
     sh cuda_${CUDA_VER}_${DRIVER_VER}_linux.run --silent --toolkit && \
     rm cuda_${CUDA_VER}_${DRIVER_VER}_linux.run && \
-    cd /usr/local/cuda/targets/x86_64-linux/lib && rm libcuspars* libcusolver*
+    cd /usr/local/cuda/lib64 && rm libcuspars* libcusolver*
+
+# TODO: move this to the base container once we confirm dynamic linking is working okay
+# Use the basename bit to ensure no rm -rf foibles with root dir in empyt string case
+RUN ls /usr/local/cuda/lib64/lib*_static.a | grep -v cufft_static.a | while read a; do rm -rf /usr/local/cuda/lib64/$(basename $a); done && \
+    rm -rf /usr/local/cuda/lib64/libcufft_static_nocallback.a
 
 RUN echo 'alias lt="ls -lrth"' >> /home/cisTEMx/.bashrc && \
     echo 'alias dU="du -ch --max-depth=1 | sort -h"' >> /home/cisTEMx/.bashrc && \
@@ -134,9 +151,6 @@ RUN tf=`tempfile` && cp /usr/include/wx-3.1-unofficial/wx/longlong.h /usr/includ
     mv $tf /usr/include/wx-3.1-unofficial/wx/longlong.h && \
     chmod a+r /usr/include/wx-3.1-unofficial/wx/longlong.h
 
-# For the static and system installs, we don't need to worry about libs being found. For the dynamic install, we need to add the lib path to LD_LIBRARY_PATH
-# Include the lib path in LD_RUN_PATH so on linking, the correct path is known 
-# ENV LD_LIBRARY_PATH=/opt/WX/intel-dynamic/lib/:${LD_LIBRARY_PATH}
 
 
 

--- a/scripts/containers/cistem_apptainer.def
+++ b/scripts/containers/cistem_apptainer.def
@@ -5,6 +5,8 @@ From: ubuntu:20.04
 %setup 
 
 mkdir -p ${SINGULARITY_ROOTFS}/.cistem_apptainer_cache
+mkdir -p ${SINGULARITY_ROOTFS}/cisTEMx
+
 
 %files
 
@@ -52,8 +54,8 @@ git xauth zip unzip parallel sqlite3 python3 python3-pip curl gdb \
 && rm -rf /var/lib/apt/lists/*
 
 # Get reference images for testing and debugging
-pip3 install gdown && cd / && gdown https://drive.google.com/drive/folders/1PO9tBU7lKqKUuSb8qdEPvlEk7xeektXv?usp --folder
-echo 'export CISTEM_REF_IMAGES=/cistem_reference_images' >>$APPTAINER_ENVIRONMENT
+pip3 install gdown && cd /cisTEMx && gdown https://drive.google.com/drive/folders/1PO9tBU7lKqKUuSb8qdEPvlEk7xeektXv?usp --folder
+echo 'export CISTEM_REF_IMAGES=/cisTEMx/cisTEMx/cistem_reference_images' >>$APPTAINER_ENVIRONMENT
 
 # Get the MKL and intel compiler: note, this is 19G by default, will try to determine minimal set needed huge waste but works well enough for now, final size is ~5gb
 wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
@@ -185,7 +187,7 @@ echo 'export NLSPATH=/opt/intel/oneapi/mkl/2021.4.0/lib/intel64/locale/%l_%t/%N'
 echo 'export CPATH=/opt/intel/oneapi/tbb/2021.4.0/env/../include:/opt/intel/oneapi/mkl/2021.4.0/include:/opt/intel/oneapi/compiler/2021.4.0/linux/include' >>$APPTAINER_ENVIRONMENT
 echo 'export LIBRARY_PATH=/opt/intel/oneapi/tbb/2021.4.0/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/mkl/2021.4.0/lib/intel64:/opt/intel/oneapi/compiler/2021.4.0/linux/compiler/lib/intel64_lin:/opt/intel/oneapi/compiler/2021.4.0/linux/lib' >>$APPTAINER_ENVIRONMENT
 # NOTE: this also has the wx dynamic in it
-echo 'export LD_LIBRARY_PATH=/opt/WX/intel-dynamic/lib/:/opt/intel/oneapi/tbb/2021.4.0/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/mkl/2021.4.0/lib/intel64:/opt/intel/oneapi/compiler/2021.4.0/linux/lib:/opt/intel/oneapi/compiler/2021.4.0/linux/lib/x64:/opt/intel/oneapi/compiler/2021.4.0/linux/lib/emu:/opt/intel/oneapi/compiler/2021.4.0/linux/compiler/lib/intel64_lin:/.singularity.d/libs' >>$APPTAINER_ENVIRONMENT
+echo 'export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/WX/intel-dynamic/lib:/opt/intel/oneapi/tbb/2021.4.0/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/mkl/2021.4.0/lib/intel64:/opt/intel/oneapi/compiler/2021.4.0/linux/lib:/opt/intel/oneapi/compiler/2021.4.0/linux/lib/x64:/opt/intel/oneapi/compiler/2021.4.0/linux/lib/emu:/opt/intel/oneapi/compiler/2021.4.0/linux/compiler/lib/intel64_lin:/.singularity.d/libs' >>$APPTAINER_ENVIRONMENT
 echo 'export PATH=/usr/local/cuda/bin${PATH:+:${PATH}}' >> $APPTAINER_ENVIRONMENT
 
 # Hack to make intel play nice with AMD

--- a/scripts/containers/cistem_apptainer_top_layer.def
+++ b/scripts/containers/cistem_apptainer_top_layer.def
@@ -48,8 +48,9 @@ export CUTENSOR_LIB=11
 cd /tmp &&   wget https://developer.download.nvidia.com/compute/cutensor/redist/libcutensor/linux-x86_64/${CUTENSOR_VERSION}.tar.xz && \
     mkdir /opt/cuTensor && tar -xf ${CUTENSOR_VERSION}.tar.xz --strip 1 -C /opt/cuTensor && \
     cd /opt/cuTensor/lib && ln -s ${CUTENSOR_LIB} cistem_version && \
+    rm -rf 10.2 ${CUTENSORLIB}/libcuten*_static.a && \
     echo 'export CUTENSOR_ROOT=/opt/cuTensor'  >>$APPTAINER_ENVIRONMENT && \ 
-    echo 'export LD_LIBRARY_PATH=${CUTENSOR_ROOT}/lib/${cistem_version}/:${LD_LIBRARY_PATH}'  >>$APPTAINER_ENVIRONMENT
+    echo 'export LD_LIBRARY_PATH=${CUTENSOR_ROOT}/lib/cistem_version/:${LD_LIBRARY_PATH}'  >>$APPTAINER_ENVIRONMENT
 
 
 echo 'export MKLROOT=/opt/intel/oneapi/mkl/2021.4.0/' >>$APPTAINER_ENVIRONMENT

--- a/scripts/containers/cistem_apptainer_top_layer.def
+++ b/scripts/containers/cistem_apptainer_top_layer.def
@@ -1,10 +1,11 @@
 Bootstrap: docker
-From: bhimesbhimes/cistem_build_env:base_image_v1.4.5
+From: bhimesbhimes/cistem_build_env:base_image_v1.5.0
 #Stage: spython-base
 
 %setup 
 
 mkdir -p ${SINGULARITY_ROOTFS}/.cistem_apptainer_cache
+mkdir -p ${SINGULARITY_ROOTFS}/cisTEMx
 
 %files
 
@@ -15,42 +16,8 @@ mkdir -p ${SINGULARITY_ROOTFS}/.cistem_apptainer_cache
 
 
 # Get reference images for testing and debugging
-pip3 install gdown && cd / && gdown https://drive.google.com/drive/folders/1PO9tBU7lKqKUuSb8qdEPvlEk7xeektXv?usp --folder
+pip3 install gdown && cd /cisTEMx && gdown https://drive.google.com/drive/folders/1PO9tBU7lKqKUuSb8qdEPvlEk7xeektXv?usp --folder
 
-# Install newest gcc
-# RUN add-apt-repository ppa:ubuntu-toolchain-r/test -y && \
-#     apt-get --allow-releaseinfo-change  update && apt install -y gcc-${GCC_VER} g++-${GCC_VER} \
-#     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VER} 100 --slave \
-#     /usr/bin/g++ g++ /usr/bin/g++-${GCC_VER} --slave /usr/bin/gcov gcov /usr/bin/gcov-${GCC_VER} \
-#     && rm -rf /var/lib/apt/lists/*
-
-
-# Here for the record if you want to build and link static binaries to avoid the cointainerized distribution
-# RUN . /opt/intel/oneapi/setvars.sh  &&  cd /tmp/wxWidgets-3.0.5 && CXX=icpc CC=icc CXXFLAGS=-fPIC CFLAGS=-fPIC  ./configure --disable-precomp-headers --prefix=/opt/WX/intel-static --with-libnotify=no --disable-shared \
-#     --without-gtkprint --with-libjpeg=builtin --with-libpng=builtin --with-libtiff=builtin --with-zlib=builtin --with-expat=builtin \
-#     --disable-compat28 --without-liblzma --without-libjbig --with-gtk=2 --disable-sys-libs  && \
-#     make -j$n_threads && \
-#     make install && make clean 
-
-
-
-# # Install Node 16
-# RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
-#     apt-get update && apt-get install -y nodejs && \
-#     rm -rf /var/lib/apt/lists/*  && \
-#     npm install -g pnpm
-# echo 'export LD_PRELOAD=/opt/intel/libfakeIntel.so' >> $APPTAINER_ENVIRONMENT
-
-# Install cutensor
-
-export CUTENSOR_VERSION=libcutensor-linux-x86_64-1.6.0.3-archive
-export CUTENSOR_LIB=11
-cd /tmp &&   wget https://developer.download.nvidia.com/compute/cutensor/redist/libcutensor/linux-x86_64/${CUTENSOR_VERSION}.tar.xz && \
-    mkdir /opt/cuTensor && tar -xf ${CUTENSOR_VERSION}.tar.xz --strip 1 -C /opt/cuTensor && \
-    cd /opt/cuTensor/lib && ln -s ${CUTENSOR_LIB} cistem_version && \
-    rm -rf 10.2 ${CUTENSORLIB}/libcuten*_static.a && \
-    echo 'export CUTENSOR_ROOT=/opt/cuTensor'  >>$APPTAINER_ENVIRONMENT && \ 
-    echo 'export LD_LIBRARY_PATH=${CUTENSOR_ROOT}/lib/cistem_version/:${LD_LIBRARY_PATH}'  >>$APPTAINER_ENVIRONMENT
 
 
 echo 'export MKLROOT=/opt/intel/oneapi/mkl/2021.4.0/' >>$APPTAINER_ENVIRONMENT
@@ -58,9 +25,9 @@ echo 'export NLSPATH=/opt/intel/oneapi/mkl/2021.4.0/lib/intel64/locale/%l_%t/%N'
 echo 'export CPATH=/opt/intel/oneapi/tbb/2021.4.0/env/../include:/opt/intel/oneapi/mkl/2021.4.0/include:/opt/intel/oneapi/compiler/2021.4.0/linux/include' >>$APPTAINER_ENVIRONMENT
 echo 'export LIBRARY_PATH=/opt/intel/oneapi/tbb/2021.4.0/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/mkl/2021.4.0/lib/intel64:/opt/intel/oneapi/compiler/2021.4.0/linux/compiler/lib/intel64_lin:/opt/intel/oneapi/compiler/2021.4.0/linux/lib' >>$APPTAINER_ENVIRONMENT
 # NOTE: this also has the wx dynamic in it
-echo 'export LD_LIBRARY_PATH=/opt/WX/intel-dynamic/lib/:/opt/intel/oneapi/tbb/2021.4.0/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/mkl/2021.4.0/lib/intel64:/opt/intel/oneapi/compiler/2021.4.0/linux/lib:/opt/intel/oneapi/compiler/2021.4.0/linux/lib/x64:/opt/intel/oneapi/compiler/2021.4.0/linux/lib/emu:/opt/intel/oneapi/compiler/2021.4.0/linux/compiler/lib/intel64_lin:/.singularity.d/libs' >>$APPTAINER_ENVIRONMENT
+echo 'export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/WX/intel-dynamic/lib:/opt/intel/oneapi/tbb/2021.4.0/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/mkl/2021.4.0/lib/intel64:/opt/intel/oneapi/compiler/2021.4.0/linux/lib:/opt/intel/oneapi/compiler/2021.4.0/linux/lib/x64:/opt/intel/oneapi/compiler/2021.4.0/linux/lib/emu:/opt/intel/oneapi/compiler/2021.4.0/linux/compiler/lib/intel64_lin:/.singularity.d/libs' >>$APPTAINER_ENVIRONMENT
 echo 'export PATH=/usr/local/cuda/bin:${PATH}' >> $APPTAINER_ENVIRONMENT
-echo 'export CISTEM_REF_IMAGES=/cistem_reference_images' >> $APPTAINER_ENVIRONMENT
+echo 'export CISTEM_REF_IMAGES=/cisTEMx/cistem_reference_images' >> $APPTAINER_ENVIRONMENT
 
 %environment
 

--- a/scripts/containers/cistem_with_code_and_tests.def
+++ b/scripts/containers/cistem_with_code_and_tests.def
@@ -25,8 +25,8 @@ mv /cisTEMx/cistem_tests.sh /cisTEMx/bin
 
 # TODO: move this to the base container once we confirm dynamic linking is working okay
 # Use the basename bit to ensure no rm -rf foibles with root dir in empyt string case
-ls /usr/local/cuda/targets/x86_64-linux/lib/libcu*_static.a | grep -v cufft_static.a | while read a; do rm -rf /usr/local/cuda/targets/x86_64-linux/lib/$(basename $a); done
-
+ls /usr/local/cuda/targets/x86_64-linux/lib/lib*_static.a | grep -v cufft_static.a | while read a; do rm -rf /usr/local/cuda/targets/x86_64-linux/lib/$(basename $a); done
+rm -f /usr/local/cuda/targets/x86_64-linux/lib/libcufft_static_nocallback.a
 # Clean out some items we don't need in production
 rm -rf /usr/local/cuda/nsight-systems-*
 rm -rf /usr/local/cuda/nsight-compute-*

--- a/scripts/containers/cistem_with_code_and_tests.def
+++ b/scripts/containers/cistem_with_code_and_tests.def
@@ -1,5 +1,5 @@
 Bootstrap: docker
-From: bhimesbhimes/cistem_build_env:base_image_v1.4.5
+From: bhimesbhimes/cistem_build_env:base_image_v1.5.0
 #Stage: spython-base
 
 %setup 
@@ -23,36 +23,17 @@ mv /cisTEMx/src /cisTEMx/bin
 mv /cisTEMx/cistem_tests.sh /cisTEMx/bin
 
 
-# TODO: move this to the base container once we confirm dynamic linking is working okay
-# Use the basename bit to ensure no rm -rf foibles with root dir in empyt string case
-ls /usr/local/cuda/targets/x86_64-linux/lib/lib*_static.a | grep -v cufft_static.a | while read a; do rm -rf /usr/local/cuda/targets/x86_64-linux/lib/$(basename $a); done
-rm -f /usr/local/cuda/targets/x86_64-linux/lib/libcufft_static_nocallback.a
 # Clean out some items we don't need in production
 rm -rf /usr/local/cuda/nsight-systems-*
 rm -rf /usr/local/cuda/nsight-compute-*
 
 
-# Right now, we aren't using libtorch or cuTensor in production
-rm -rf /opt/libtorch
-
 
 # Get reference images for testing and debugging
-pip3 install gdown && cd / && gdown https://drive.google.com/drive/folders/1PO9tBU7lKqKUuSb8qdEPvlEk7xeektXv?usp --folder
+pip3 install gdown && cd /cisTEMx && gdown https://drive.google.com/drive/folders/1PO9tBU7lKqKUuSb8qdEPvlEk7xeektXv?usp --folder
 
 chmod a+x /cisTEMx/* 
 
-
-
-# Install cutensor
-
-export CUTENSOR_VERSION=libcutensor-linux-x86_64-1.6.0.3-archive
-export CUTENSOR_LIB=11
-cd /tmp &&   wget https://developer.download.nvidia.com/compute/cutensor/redist/libcutensor/linux-x86_64/${CUTENSOR_VERSION}.tar.xz && \
-    mkdir /opt/cuTensor && tar -xf ${CUTENSOR_VERSION}.tar.xz --strip 1 -C /opt/cuTensor && \
-    cd /opt/cuTensor/lib && ln -s ${CUTENSOR_LIB} cistem_version && \
-    rm -rf 10.2 ${CUTENSORLIB}/libcuten*_static.a && \
-    echo 'export CUTENSOR_ROOT=/opt/cuTensor'  >>$APPTAINER_ENVIRONMENT && \ 
-    echo 'export LD_LIBRARY_PATH=${CUTENSOR_ROOT}/lib/cistem_version/:${LD_LIBRARY_PATH}'  >>$APPTAINER_ENVIRONMENT
 
 
 echo 'export MKLROOT=/opt/intel/oneapi/mkl/2021.4.0/' >>$APPTAINER_ENVIRONMENT
@@ -60,9 +41,9 @@ echo 'export NLSPATH=/opt/intel/oneapi/mkl/2021.4.0/lib/intel64/locale/%l_%t/%N'
 echo 'export CPATH=/opt/intel/oneapi/tbb/2021.4.0/env/../include:/opt/intel/oneapi/mkl/2021.4.0/include:/opt/intel/oneapi/compiler/2021.4.0/linux/include' >>$APPTAINER_ENVIRONMENT
 echo 'export LIBRARY_PATH=/opt/intel/oneapi/tbb/2021.4.0/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/mkl/2021.4.0/lib/intel64:/opt/intel/oneapi/compiler/2021.4.0/linux/compiler/lib/intel64_lin:/opt/intel/oneapi/compiler/2021.4.0/linux/lib' >>$APPTAINER_ENVIRONMENT
 # NOTE: this also has the wx dynamic in it
-echo 'export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/WX/intel-dynamic/lib/:/usr/local/cuda/lib64:/opt/intel/oneapi/tbb/2021.4.0/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/mkl/2021.4.0/lib/intel64:/opt/intel/oneapi/compiler/2021.4.0/linux/lib:/opt/intel/oneapi/compiler/2021.4.0/linux/lib/x64:/opt/intel/oneapi/compiler/2021.4.0/linux/lib/emu:/opt/intel/oneapi/compiler/2021.4.0/linux/compiler/lib/intel64_lin:/.singularity.d/libs' >>$APPTAINER_ENVIRONMENT
+echo 'export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/WX/intel-dynamic/lib:/usr/local/cuda/lib64:/opt/intel/oneapi/tbb/2021.4.0/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/mkl/2021.4.0/lib/intel64:/opt/intel/oneapi/compiler/2021.4.0/linux/lib:/opt/intel/oneapi/compiler/2021.4.0/linux/lib/x64:/opt/intel/oneapi/compiler/2021.4.0/linux/lib/emu:/opt/intel/oneapi/compiler/2021.4.0/linux/compiler/lib/intel64_lin:/.singularity.d/libs' >>$APPTAINER_ENVIRONMENT
 echo 'export PATH=/usr/local/cuda/bin:/cisTEMx/src:${PATH}' >> $APPTAINER_ENVIRONMENT
-echo 'export CISTEM_REF_IMAGES=/cistem_reference_images' >> $APPTAINER_ENVIRONMENT
+echo 'export CISTEM_REF_IMAGES=/cisTEMx/cistem_reference_images' >> $APPTAINER_ENVIRONMENT
 
 
 

--- a/scripts/containers/cistem_with_code_and_tests.def
+++ b/scripts/containers/cistem_with_code_and_tests.def
@@ -22,13 +22,17 @@ mkdir -p ${SINGULARITY_ROOTFS}/cisTEMx/scripts
 mv /cisTEMx/src /cisTEMx/bin
 mv /cisTEMx/cistem_tests.sh /cisTEMx/bin
 
+
+# TODO: move this to the base container once we confirm dynamic linking is working okay
+# Use the basename bit to ensure no rm -rf foibles with root dir in empyt string case
+ls /usr/local/cuda/targets/x86_64-linux/lib/libcu*_static.a | grep -v cufft_static.a | while read a; do rm -rf /usr/local/cuda/targets/x86_64-linux/lib/$(basename $a); done
+
 # Clean out some items we don't need in production
 rm -rf /usr/local/cuda/nsight-systems-*
 rm -rf /usr/local/cuda/nsight-compute-*
-# I think I only need the static, but this may break pytorch or cutensor
-rm /usr/local/cuda/targets/x86_64-linux/lib/libcublasLt.so*
+
+
 # Right now, we aren't using libtorch or cuTensor in production
-rm -rf /opt/cuTensor
 rm -rf /opt/libtorch
 
 
@@ -41,13 +45,14 @@ chmod a+x /cisTEMx/*
 
 # Install cutensor
 
-# export CUTENSOR_VERSION=libcutensor-linux-x86_64-1.6.0.3-archive
-# export CUTENSOR_LIB=11
-# cd /tmp &&   wget https://developer.download.nvidia.com/compute/cutensor/redist/libcutensor/linux-x86_64/${CUTENSOR_VERSION}.tar.xz && \
-#     mkdir /opt/cuTensor && tar -xf ${CUTENSOR_VERSION}.tar.xz --strip 1 -C /opt/cuTensor && \
-#     cd /opt/cuTensor/lib && ln -s ${CUTENSOR_LIB} cistem_version && \
-#     echo 'export CUTENSOR_ROOT=/opt/cuTensor'  >>$APPTAINER_ENVIRONMENT && \ 
-#     echo 'export LD_LIBRARY_PATH=${CUTENSOR_ROOT}/lib/${cistem_version}/:${LD_LIBRARY_PATH}'  >>$APPTAINER_ENVIRONMENT
+export CUTENSOR_VERSION=libcutensor-linux-x86_64-1.6.0.3-archive
+export CUTENSOR_LIB=11
+cd /tmp &&   wget https://developer.download.nvidia.com/compute/cutensor/redist/libcutensor/linux-x86_64/${CUTENSOR_VERSION}.tar.xz && \
+    mkdir /opt/cuTensor && tar -xf ${CUTENSOR_VERSION}.tar.xz --strip 1 -C /opt/cuTensor && \
+    cd /opt/cuTensor/lib && ln -s ${CUTENSOR_LIB} cistem_version && \
+    rm -rf 10.2 ${CUTENSORLIB}/libcuten*_static.a && \
+    echo 'export CUTENSOR_ROOT=/opt/cuTensor'  >>$APPTAINER_ENVIRONMENT && \ 
+    echo 'export LD_LIBRARY_PATH=${CUTENSOR_ROOT}/lib/cistem_version/:${LD_LIBRARY_PATH}'  >>$APPTAINER_ENVIRONMENT
 
 
 echo 'export MKLROOT=/opt/intel/oneapi/mkl/2021.4.0/' >>$APPTAINER_ENVIRONMENT
@@ -55,7 +60,7 @@ echo 'export NLSPATH=/opt/intel/oneapi/mkl/2021.4.0/lib/intel64/locale/%l_%t/%N'
 echo 'export CPATH=/opt/intel/oneapi/tbb/2021.4.0/env/../include:/opt/intel/oneapi/mkl/2021.4.0/include:/opt/intel/oneapi/compiler/2021.4.0/linux/include' >>$APPTAINER_ENVIRONMENT
 echo 'export LIBRARY_PATH=/opt/intel/oneapi/tbb/2021.4.0/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/mkl/2021.4.0/lib/intel64:/opt/intel/oneapi/compiler/2021.4.0/linux/compiler/lib/intel64_lin:/opt/intel/oneapi/compiler/2021.4.0/linux/lib' >>$APPTAINER_ENVIRONMENT
 # NOTE: this also has the wx dynamic in it
-echo 'export LD_LIBRARY_PATH=/opt/WX/intel-dynamic/lib/:/opt/intel/oneapi/tbb/2021.4.0/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/mkl/2021.4.0/lib/intel64:/opt/intel/oneapi/compiler/2021.4.0/linux/lib:/opt/intel/oneapi/compiler/2021.4.0/linux/lib/x64:/opt/intel/oneapi/compiler/2021.4.0/linux/lib/emu:/opt/intel/oneapi/compiler/2021.4.0/linux/compiler/lib/intel64_lin:/.singularity.d/libs' >>$APPTAINER_ENVIRONMENT
+echo 'export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/WX/intel-dynamic/lib/:/usr/local/cuda/lib64:/opt/intel/oneapi/tbb/2021.4.0/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/mkl/2021.4.0/lib/intel64:/opt/intel/oneapi/compiler/2021.4.0/linux/lib:/opt/intel/oneapi/compiler/2021.4.0/linux/lib/x64:/opt/intel/oneapi/compiler/2021.4.0/linux/lib/emu:/opt/intel/oneapi/compiler/2021.4.0/linux/compiler/lib/intel64_lin:/.singularity.d/libs' >>$APPTAINER_ENVIRONMENT
 echo 'export PATH=/usr/local/cuda/bin:/cisTEMx/src:${PATH}' >> $APPTAINER_ENVIRONMENT
 echo 'export CISTEM_REF_IMAGES=/cistem_reference_images' >> $APPTAINER_ENVIRONMENT
 

--- a/scripts/containers/cistem_with_tests.def
+++ b/scripts/containers/cistem_with_tests.def
@@ -58,8 +58,9 @@ export CUTENSOR_LIB=11
 cd /tmp &&   wget https://developer.download.nvidia.com/compute/cutensor/redist/libcutensor/linux-x86_64/${CUTENSOR_VERSION}.tar.xz && \
     mkdir /opt/cuTensor && tar -xf ${CUTENSOR_VERSION}.tar.xz --strip 1 -C /opt/cuTensor && \
     cd /opt/cuTensor/lib && ln -s ${CUTENSOR_LIB} cistem_version && \
+    rm -rf 10.2 ${CUTENSORLIB}/libcuten*_static.a && \
     echo 'export CUTENSOR_ROOT=/opt/cuTensor'  >>$APPTAINER_ENVIRONMENT && \ 
-    echo 'export LD_LIBRARY_PATH=${CUTENSOR_ROOT}/lib/${cistem_version}/:${LD_LIBRARY_PATH}'  >>$APPTAINER_ENVIRONMENT
+    echo 'export LD_LIBRARY_PATH=${CUTENSOR_ROOT}/lib/cistem_version/:${LD_LIBRARY_PATH}'  >>$APPTAINER_ENVIRONMENT
 
 
 echo 'export MKLROOT=/opt/intel/oneapi/mkl/2021.4.0/' >>$APPTAINER_ENVIRONMENT

--- a/scripts/containers/cistem_with_tests.def
+++ b/scripts/containers/cistem_with_tests.def
@@ -1,5 +1,5 @@
 Bootstrap: docker
-From: bhimesbhimes/cistem_build_env:base_image_v1.4.5
+From: bhimesbhimes/cistem_build_env:base_image_v1.5.0
 #Stage: spython-base
 
 %setup 
@@ -24,43 +24,12 @@ mkdir -p ${SINGULARITY_ROOTFS}/cisTEMx/src
 
 
 # Get reference images for testing and debugging
-pip3 install gdown && cd / && gdown https://drive.google.com/drive/folders/1PO9tBU7lKqKUuSb8qdEPvlEk7xeektXv?usp --folder
+pip3 install gdown && cd /cisTEMx && gdown https://drive.google.com/drive/folders/1PO9tBU7lKqKUuSb8qdEPvlEk7xeektXv?usp --folder
 
 chmod a+x /cisTEMx/src/* 
-# Install newest gcc
-# RUN add-apt-repository ppa:ubuntu-toolchain-r/test -y && \
-#     apt-get --allow-releaseinfo-change  update && apt install -y gcc-${GCC_VER} g++-${GCC_VER} \
-#     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VER} 100 --slave \
-#     /usr/bin/g++ g++ /usr/bin/g++-${GCC_VER} --slave /usr/bin/gcov gcov /usr/bin/gcov-${GCC_VER} \
-#     && rm -rf /var/lib/apt/lists/*
-
-
-# Here for the record if you want to build and link static binaries to avoid the cointainerized distribution
-# RUN . /opt/intel/oneapi/setvars.sh  &&  cd /tmp/wxWidgets-3.0.5 && CXX=icpc CC=icc CXXFLAGS=-fPIC CFLAGS=-fPIC  ./configure --disable-precomp-headers --prefix=/opt/WX/intel-static --with-libnotify=no --disable-shared \
-#     --without-gtkprint --with-libjpeg=builtin --with-libpng=builtin --with-libtiff=builtin --with-zlib=builtin --with-expat=builtin \
-#     --disable-compat28 --without-liblzma --without-libjbig --with-gtk=2 --disable-sys-libs  && \
-#     make -j$n_threads && \
-#     make install && make clean 
 
 
 
-# # Install Node 16
-# RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
-#     apt-get update && apt-get install -y nodejs && \
-#     rm -rf /var/lib/apt/lists/*  && \
-#     npm install -g pnpm
-# echo 'export LD_PRELOAD=/opt/intel/libfakeIntel.so' >> $APPTAINER_ENVIRONMENT
-
-# Install cutensor
-
-export CUTENSOR_VERSION=libcutensor-linux-x86_64-1.6.0.3-archive
-export CUTENSOR_LIB=11
-cd /tmp &&   wget https://developer.download.nvidia.com/compute/cutensor/redist/libcutensor/linux-x86_64/${CUTENSOR_VERSION}.tar.xz && \
-    mkdir /opt/cuTensor && tar -xf ${CUTENSOR_VERSION}.tar.xz --strip 1 -C /opt/cuTensor && \
-    cd /opt/cuTensor/lib && ln -s ${CUTENSOR_LIB} cistem_version && \
-    rm -rf 10.2 ${CUTENSORLIB}/libcuten*_static.a && \
-    echo 'export CUTENSOR_ROOT=/opt/cuTensor'  >>$APPTAINER_ENVIRONMENT && \ 
-    echo 'export LD_LIBRARY_PATH=${CUTENSOR_ROOT}/lib/cistem_version/:${LD_LIBRARY_PATH}'  >>$APPTAINER_ENVIRONMENT
 
 
 echo 'export MKLROOT=/opt/intel/oneapi/mkl/2021.4.0/' >>$APPTAINER_ENVIRONMENT
@@ -68,9 +37,9 @@ echo 'export NLSPATH=/opt/intel/oneapi/mkl/2021.4.0/lib/intel64/locale/%l_%t/%N'
 echo 'export CPATH=/opt/intel/oneapi/tbb/2021.4.0/env/../include:/opt/intel/oneapi/mkl/2021.4.0/include:/opt/intel/oneapi/compiler/2021.4.0/linux/include' >>$APPTAINER_ENVIRONMENT
 echo 'export LIBRARY_PATH=/opt/intel/oneapi/tbb/2021.4.0/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/mkl/2021.4.0/lib/intel64:/opt/intel/oneapi/compiler/2021.4.0/linux/compiler/lib/intel64_lin:/opt/intel/oneapi/compiler/2021.4.0/linux/lib' >>$APPTAINER_ENVIRONMENT
 # NOTE: this also has the wx dynamic in it
-echo 'export LD_LIBRARY_PATH=/opt/WX/intel-dynamic/lib/:/opt/intel/oneapi/tbb/2021.4.0/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/mkl/2021.4.0/lib/intel64:/opt/intel/oneapi/compiler/2021.4.0/linux/lib:/opt/intel/oneapi/compiler/2021.4.0/linux/lib/x64:/opt/intel/oneapi/compiler/2021.4.0/linux/lib/emu:/opt/intel/oneapi/compiler/2021.4.0/linux/compiler/lib/intel64_lin:/.singularity.d/libs' >>$APPTAINER_ENVIRONMENT
+echo 'export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/WX/intel-dynamic/lib:/opt/intel/oneapi/tbb/2021.4.0/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/mkl/2021.4.0/lib/intel64:/opt/intel/oneapi/compiler/2021.4.0/linux/lib:/opt/intel/oneapi/compiler/2021.4.0/linux/lib/x64:/opt/intel/oneapi/compiler/2021.4.0/linux/lib/emu:/opt/intel/oneapi/compiler/2021.4.0/linux/compiler/lib/intel64_lin:/.singularity.d/libs' >>$APPTAINER_ENVIRONMENT
 echo 'export PATH=/usr/local/cuda/bin:/cisTEMx/src:${PATH}' >> $APPTAINER_ENVIRONMENT
-echo 'export CISTEM_REF_IMAGES=/cistem_reference_images' >> $APPTAINER_ENVIRONMENT
+echo 'export CISTEM_REF_IMAGES=/cisTEMx/cistem_reference_images' >> $APPTAINER_ENVIRONMENT
 
 
 

--- a/scripts/testing/beta_gal_benchmark/run_benchmark.sh
+++ b/scripts/testing/beta_gal_benchmark/run_benchmark.sh
@@ -9,7 +9,7 @@ expected_local_runtime=63
 expected_recon_runtime=30
 max_run_time=$(($expected_global_runtime + $expected_local_runtime + $expected_recon_runtime))
 
-data_dir=/cistem_reference_images/betagal_benchmark
+data_dir=/cisTEMx/cistem_reference_images/betagal_benchmark
 
 # Run as
 # apptainer run --nv current_runtime_version.sif bgal


### PR DESCRIPTION
# Description

Confirmed that cufft must still be static for callbacks to work in TM, but all binaries are down from ~680M to ~180M which is still a big improvement in total space. 

I'd rather deal with this volume and not lose 10-20% performance, since I'll work on the FastFFT again anyway.

# Fixes 
 #43 

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [ ] yes
- [ ] no

# These changes are isolated to the

- [ ] gui
- [ ] core library
- [ ] gpu core library
- [ ] program it modifies

# This build was done using the cistem_build_env docker container

- [ ] yes
- [ ] no

# Checklist:

- [ ] I have not changed anything that did not need to be changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
