### PR TITLE
Adds fp16 read in mrc_file, no support for write, converts to fp32

### DIFF
--- a/src/core/mrc_file.cpp
+++ b/src/core/mrc_file.cpp
@@ -1,4 +1,7 @@
 #include "core_headers.h"
+#include "../../include/ieee-754-half/half.hpp"
+
+using namespace half_float;
 
 MRCFile::MRCFile( ) {
     rewrite_header_on_close                         = false;
@@ -244,6 +247,18 @@ void MRCFile::ReadSlicesFromDisk(int start_slice, int end_slice, float* output_a
             case 2:
                 my_file->read((char*)output_array, records_to_read * 4);
                 break;
+
+            // 2-byte real
+            case 12: {
+                half* temp_half_array = new half[records_to_read];
+                my_file->read((char*)temp_half_array, records_to_read * 2);
+
+                for ( long counter = 0; counter < records_to_read; counter++ ) {
+                    // float() operator overloaded in half_float namespace
+                    output_array[counter] = float(temp_half_array[counter]);
+                }
+                delete[] temp_half_array;
+            } break;
 
             // unsigned 2-byte integers
             case 6: {

--- a/src/core/mrc_header.cpp
+++ b/src/core/mrc_header.cpp
@@ -234,16 +234,24 @@ void MRCHeader::ReadHeader(std::fstream* MRCFile) {
         case 1:
             bytes_per_pixel        = 2;
             pixel_data_are_signed  = true;
-            pixel_data_are_of_type = Float;
+            pixel_data_are_of_type = Float; // FIXME: Why are we using defintions from multiple enums (this from dm.h others from mrc_header.h)
             pixel_data_are_complex = false;
             break;
 
         case 2:
             bytes_per_pixel        = 4;
             pixel_data_are_signed  = true;
-            pixel_data_are_of_type = MRCByte;
+            pixel_data_are_of_type = MRCByte; // FIXME: Why is this not MRCFloat?
             pixel_data_are_complex = false;
             break;
+
+        case 12: {
+            bytes_per_pixel        = 2;
+            pixel_data_are_signed  = true;
+            pixel_data_are_of_type = MRCFloat16;
+            pixel_data_are_complex = false;
+            break;
+        }
 
         case 3:
             bytes_per_pixel        = 2;

--- a/src/core/mrc_header.h
+++ b/src/core/mrc_header.h
@@ -49,6 +49,7 @@
 enum MRCDataTypes { MRCByte,
                     MRCInteger,
                     MRCFloat,
+                    MRCFloat16,
                     MRC4Bit };
 
 class MRCHeader {

--- a/src/programs/quick_test/quick_test.cpp
+++ b/src/programs/quick_test/quick_test.cpp
@@ -33,33 +33,9 @@ void QuickTestApp::DoInteractiveUserInput( ) {
 
 bool QuickTestApp::DoCalculation( ) {
 
-    Image mip, avg, std;
-    mip.QuickAndDirtyReadSlice("/scratch/siracusa/proc_EMPIAR-10894-KRas-G13D-SOS/small_test/Assets/TemplateMatching/n20aug20e_b2g1_00009gr_00002sq_v02_00002hln_00004esn.frames_3_0_mip_3_0.mrc", 1);
-    avg.QuickAndDirtyReadSlice("/scratch/siracusa/proc_EMPIAR-10894-KRas-G13D-SOS/small_test/Assets/TemplateMatching/n20aug20e_b2g1_00009gr_00002sq_v02_00002hln_00004esn.frames_3_0_avg_3_0.mrc", 1);
-    std.QuickAndDirtyReadSlice("/scratch/siracusa/proc_EMPIAR-10894-KRas-G13D-SOS/small_test/Assets/TemplateMatching/n20aug20e_b2g1_00009gr_00002sq_v02_00002hln_00004esn.frames_3_0_std_3_0.mrc", 1);
-
-    float pixel_size                    = 1.2f;
-    float objective_aperture_resolution = 188.0f;
-    float mask_falloff                  = 7.f;
-    mip.ReturnCosineMaskBandpassResolution(pixel_size, objective_aperture_resolution, mask_falloff);
-    // Masks for scattering inside (0) and outside (1) the objective aperture.
-
-    std::string test_base = "cutoff_300_control.mrc";
-    mip.QuickAndDirtyWriteSlice("/scratch/siracusa/proc_EMPIAR-10894-KRas-G13D-SOS/small_test/Assets/TemplateMatching/mip_" + test_base, 1);
-    avg.ForwardFFT( );
-    std.ForwardFFT( );
-    avg.CosineRingMask(-1.0f, objective_aperture_resolution, mask_falloff);
-    std.CosineRingMask(-1.0f, objective_aperture_resolution, mask_falloff);
-    avg.BackwardFFT( );
-    std.BackwardFFT( );
-    mip.SubtractImage(&avg);
-    for ( int pixel_counter = 0; pixel_counter < mip.real_memory_allocated; pixel_counter++ ) {
-        mip.real_values[pixel_counter] = (std.real_values[pixel_counter] > 0.000001) ? mip.real_values[pixel_counter] / std.real_values[pixel_counter] : 0.0f;
-    }
-    mip.QuickAndDirtyWriteSlice("/scratch/siracusa/proc_EMPIAR-10894-KRas-G13D-SOS/small_test/Assets/TemplateMatching/scaled_mip_" + test_base, 1);
-    avg.QuickAndDirtyWriteSlice("/scratch/siracusa/proc_EMPIAR-10894-KRas-G13D-SOS/small_test/Assets/TemplateMatching/avg_" + test_base, 1);
-
-    std.QuickAndDirtyWriteSlice("/scratch/siracusa/proc_EMPIAR-10894-KRas-G13D-SOS/small_test/Assets/TemplateMatching/std_" + test_base, 1);
+    Image fp;
+    fp.QuickAndDirtyReadSlices("/home/himesb/for_auto_testing/bgal_stack.mrc", 1, 10);
+    fp.QuickAndDirtyWriteSlices("/home/himesb/for_auto_testing/bgal_stack_2.mrc", 1, 10);
 
     exit(0);
     RotationMatrix my_rotation_matrix;


### PR DESCRIPTION
# Description

Introduces fp16 i/o, though only on the read.

The immediate goal is to shrink the size of the test data for benchmarking. Longer term, will be used to reduce memory consumption and increase bandwidth during actual processing.

# Fixes 
 #42 

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [ ] yes
- [ ] no

# These changes are isolated to the

- [ ] gui
- [ ] core library
- [ ] gpu core library
- [ ] program it modifies

# This build was done using the cistem_build_env docker container

- [ ] yes
- [ ] no

# Checklist:

- [ ] I have not changed anything that did not need to be changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
